### PR TITLE
Refactoring events, adding testing frameworks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,6 @@ Cargo.lock
 *.sln
 *.sw?
 
-# local test data
+# local test data and binaries for test setup
 local/
+msedgedriver.exe

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-# AEON Sketchbook Architecture
+# Sketchbook Architecture
 
 This document gives a general rationale behind the chosen architecture and technologies.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ First, make sure you have Rust and NPM installed. For Rust, we recommend followi
 We have tested the app using following versions:
 - npm 10.9.0 
 - node 22.11.0
-- rust 1.77.1
+- rust 1.82.0
 
 Then, after cloning the repository, run `npm install` to download all JS/TS dependencies. Rust dependencies are downloaded automatically during build (next step).
 
@@ -43,16 +43,25 @@ For all the following, run the cargo commands inside `src-tauri` folder, and esl
 
 For format checking/fixing for TypeScript part of the project, you can run `npx eslint "src/**/*.{js,jsx,ts,tsx}" --config .eslintrc.yml --fix`. You can use `cargo fmt` and `cargo clippy` for the Rust side.
 
-To run the full Rust test suite, use `cargo test`.
+To run the full Rust test suite, use `cargo test`. To run the TypeScript tests, run `npx vitest --run` or `npm test`.
+
 
 To automatically generate Rust documentation, execute `cargo doc --no-deps --document-private-items`.
 
 All previous commands together for simplicity:
 ```
 npx eslint "src/**/*.{js,jsx,ts,tsx}" --config .eslintrc.yml --fix
+npx vitest --run
 cd src-tauri
 cargo fmt
 cargo clippy
 cargo test
 cargo doc --no-deps --document-private-items
 ```
+
+#### End-to-end tests
+We also provide an end-to-end Selenium-based testing framework. Note that these tests may require additional dependencies, and they are limited for Linux and Windows (due to MacOS issues with WebDriver). 
+
+You can follow this [detailed tutorial](https://jonaskruckenberg.github.io/tauri-docs-wip/development/testing.html). In short, you should install `tauri-driver` (with `cargo install tauri-driver`) and then either `WebKitWebDriver` on Linux, or `Microsoft Edge Driver` on Windows (make sure that you have updated Microsoft Edge too). Test runner can be installed with `npm install mocha chai selenium-webdriver`. 
+To run the tests, first build the app with `cargo tauri build` and then use `npx mocha`. 
+The framework was tested on Windows with `Microsoft Edge WebDriver` version `130.0.2849.89`.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,17 @@ Boolean network sketches: a unifying framework for logical model inference.
 Bioinformatics, 39(4), https://doi.org/10.1093/bioinformatics/btad158.
 ```
 
+## Installation
+
+We provide pre-built binaries and installation files for the application in the [release section](https://github.com/sybila/biodivine-sketchbook/releases) (includes versions for Windows, Linux and macOS). To start using Sketchbook, download binary for your operating system - you choose between `.app` and `.dmg` for macOS, `.AppImage` or `.deb` for Linux, and `.exe` or `.msi` for Windows.
+
+> Note that the binaries are not signed, so macOS and Windows will likely ask if you trust the application or otherwise require you to explicitly allow it to run. We do not include instructions for these steps.
+
+Alternatively, if you want to build the tool locally, the instructions are provided below in the Development guide. Note that the local build requires installing additional dependencies.
+
 ## Development
+
+The following instructions desribe the local installation of the application and relevant frameworks. We recommend using the pre-built binaries described in the previous section.
 
 ### Installation of dependencies
 
@@ -34,7 +44,7 @@ Then, after cloning the repository, run `npm install` to download all JS/TS depe
 ### Building the app
 
 To build a release version of the app, run `npm run build`. Note that the first build can take a few minutes as the application backend needs to be compiled. Subsequent builds should be faster. 
-To properly build the full release bundle for the app, you can also use `cargo tauri build`.
+To properly build the full installation file for the app, you can also use `cargo tauri build`. It will create an installation bundle at `src-tauri/target/release/bundle`.
 
 To start the application in debug mode, run `npm run tauri dev`. Note that upon startup, the application window can be unresponsive for a few seconds when using development mode. This is because the whole application is running in debug mode without optimizations. This startup delay should be substantially reduced when using the release binaries produced by `npm run build`.
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,58 @@
-# [Work in progress] AEON Sketchbook
+# Biodivine SketchBook
 
-AEON Sketchbook is a multi-platform application for designing and analysing large-scale logical models.
+SketchBook is a multi-platform application for synthesis of Boolean network models.
+It provides a user-friendly way to integrate various kinds of prior knowledge and experimental data into a Boolean network sketch, and then infer admissible BNs.
+
+### Boolean network sketches
+
+Boolean network sketches were introduced in [this paper](https://doi.org/10.1093/bioinformatics/btad158).
+
+### Citation
+
+If you used SketchBook for some academic work, we'd be very happy if you could cite it using 
+the following publication:
+
+```
+Beneš, N., Brim, L., Huvar, O., Pastva, S., & Šafránek, D. (2023). 
+Boolean network sketches: a unifying framework for logical model inference.
+Bioinformatics, 39(4), https://doi.org/10.1093/bioinformatics/btad158.
+```
 
 ## Development
 
-Make sure you have Rust and NPM installed. Then, after cloning, run `npm install` to download all JS/TS dependencies. To start the application in debug mode, run `npm run tauri dev`. To build a release version of the app, run `npm run build`. Note that the first build can take a few minutes as the application backend needs to be compiled. Subsequent builds should be faster. Furthermore, upon startup, the application window can be unresponsive for a few seconds when running using `npm run tauri dev`. This is because the whole application is running in debug mode without optimizations. This startup delay should be substantially reduced when using the release binaries produced by `npm run build`.
+### Installation of dependencies
 
-To properly the build the app (creating the release bundle), you can also directly use `cargo tauri build`.
+First, make sure you have Rust and NPM installed. For Rust, we recommend following the instructions on [rustlang.org](https://www.rust-lang.org/learn/get-started). For instructions on NPM and Node installation, feel free to check [their website](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
 
-For format checking/fixing, running tests suite, and auto-generating docs, you can use the following commands.
-Run the cargo commands inside `src-tauri` folder, and eslint in the main directory.
-- `npx eslint src --config .eslintrc.yml  --ext .js,.jsx,.ts,.tsx --fix`
-- `cargo fmt`
-- `cargo clippy`
-- `cargo test`
-- `cargo doc --no-deps --document-private-items`
+We have tested the app using following versions:
+- npm 10.9.0 
+- node 22.11.0
+- rust 1.77.1
+
+Then, after cloning the repository, run `npm install` to download all JS/TS dependencies. Rust dependencies are downloaded automatically during build (next step).
+
+### Building the app
+
+To build a release version of the app, run `npm run build`. Note that the first build can take a few minutes as the application backend needs to be compiled. Subsequent builds should be faster. 
+To properly build the full release bundle for the app, you can also use `cargo tauri build`.
+
+To start the application in debug mode, run `npm run tauri dev`. Note that upon startup, the application window can be unresponsive for a few seconds when using development mode. This is because the whole application is running in debug mode without optimizations. This startup delay should be substantially reduced when using the release binaries produced by `npm run build`.
+
+### Static analysis, tests, documentation
+For all the following, run the cargo commands inside `src-tauri` folder, and eslint in the main directory.
+
+For format checking/fixing for TypeScript part of the project, you can run `npx eslint "src/**/*.{js,jsx,ts,tsx}" --config .eslintrc.yml --fix`. You can use `cargo fmt` and `cargo clippy` for the Rust side.
+
+To run the full Rust test suite, use `cargo test`.
+
+To automatically generate Rust documentation, execute `cargo doc --no-deps --document-private-items`.
+
+All previous commands together for simplicity:
+```
+npx eslint "src/**/*.{js,jsx,ts,tsx}" --config .eslintrc.yml --fix
+cd src-tauri
+cargo fmt
+cargo clippy
+cargo test
+cargo doc --no-deps --document-private-items
+```

--- a/docs/events-structure.md
+++ b/docs/events-structure.md
@@ -1,0 +1,369 @@
+
+# Overview
+
+This document provides an overview of the events that can be processed by the backend state API. Events are structured in a hierarchical manner to simplify navigation and understanding.
+
+
+---
+## Undo Stack
+- **Path**: `['undo_stack', 'undo']`
+  - **Description**: Undo the last action.
+  - **Payload**: None
+- **Path**: `['undo_stack', 'redo']`
+  - **Description**: Redo the last undone action.
+  - **Payload**: None
+
+
+---
+## Tab Bar
+- **Path**: `['tab_bar', 'active']`
+  - **Description**: Set the active tab.
+  - **Payload**: `{ "tabId": "number" }`
+- **Path**: `['tab_bar', 'pin']`
+  - **Description**: Pin a tab.
+  - **Payload**: `{ "tabId": "number" }`
+- **Path**: `['tab_bar', 'unpin']`
+  - **Description**: Unpin a tab.
+  - **Payload**: `{ "tabId": "number" }`
+
+
+---
+## Sketch
+- **Path**: `['sketch', 'refresh']`
+  - **Description**: Refresh the whole sketch.
+  - **Payload**: None
+- **Path**: `['sketch', 'export_sketch']`
+  - **Description**: Export the sketch data to a custom JSON format.
+  - **Payload**: `{ "path": "string" }`
+- **Path**: `['sketch', 'export_aeon']`
+  - **Description**: Export the sketch data to an extended AEON format.
+  - **Payload**: `{ "path": "string" }`
+- **Path**: `['sketch', 'import_sketch']`
+  - **Description**: Import sketch data from a JSON file.
+  - **Payload**: `{ "path": "string" }`
+- **Path**: `['sketch', 'import_aeon']`
+  - **Description**: Import sketch data from an AEON file.
+  - **Payload**: `{ "path": "string" }`
+- **Path**: `['sketch', 'import_sbml']`
+  - **Description**: Import a model from an SBML file.
+  - **Payload**: `{ "path": "string" }`
+- **Path**: `['sketch', 'new_sketch']`
+  - **Description**: Set the sketch to a default state, clearing all data.
+  - **Payload**: None
+- **Path**: `['sketch', 'set_annotation']`
+  - **Description**: Set a new annotation for the sketch.
+  - **Payload**: `{ "annotation": "string" }`
+- **Path**: `['sketch', 'check_consistency']`
+  - **Description**: Run a consistency check on the sketch.
+  - **Payload**: None
+
+---
+
+### Model Events
+
+#### Model Refresh Events
+
+- **Path**: `['sketch', 'model', 'refresh']`
+  - **Description**: Refresh the entire model.
+  - **Payload**: None
+- **Path**: `['sketch', 'model', 'variables', 'refresh']`
+  - **Description**: Refresh the model variables.
+  - **Payload**: None
+- **Path**: `['sketch', 'model', 'uninterpreted_fns', 'refresh']`
+  - **Description**: Refresh the uninterpreted functions.
+  - **Payload**: None
+- **Path**: `['sketch', 'model', 'regulations', 'refresh']`
+  - **Description**: Refresh the regulations.
+  - **Payload**: None
+- **Path**: `['sketch', 'model', 'layouts', 'refresh']`
+  - **Description**: Refresh the layouts.
+  - **Payload**: None
+
+#### Model Variable Events
+- **Path**: `['sketch', 'model', 'variable', 'add_default']`
+  - **Description**: Add a new variable at the specified position.
+  - **Payload**:
+    ```json
+    {
+      "position": [{ "layout": "string", "px": "number", "py": "number" }]
+    }
+    ```
+- **Path**: `['sketch', 'model', 'variable', 'remove']`
+  - **Description**: Remove a variable by ID.
+  - **Payload**: `{ "varId": "string" }`
+- **Path**: `['sketch', 'model', 'variable', 'set_data']`
+  - **Description**: Update the data of a variable by ID.
+  - **Payload**:
+    ```json
+    {
+      "varId": "string",
+      "data": { "name": "string", "annotation": "string" }
+    }
+    ```
+- **Path**: `['sketch', 'model', 'variable', 'set_update_fn']`
+  - **Description**: Set the update function for a variable.
+  - **Payload**: `{ "varId": "string", "expression": "string" }`
+
+#### Model Functions Events
+
+- **Path**: `['sketch', 'model', 'uninterpreted_fn', 'add_default']`
+  - **Description**: Add a new uninterpreted function.
+  - **Payload**: None
+- **Path**: `['sketch', 'model', 'uninterpreted_fn', 'remove']`
+  - **Description**: Remove an uninterpreted function by ID.
+  - **Payload**: `{ "fnId": "string" }`
+- **Path**: `['sketch', 'model', 'uninterpreted_fn', 'set_data']`
+  - **Description**: Update data of an uninterpreted function.
+  - **Payload**:
+    ```json
+    {
+      "fnId": "string",
+      "data": { "name": "string", "annotation": "string", "expression": "string" }
+    }
+    ```
+
+#### Model Regulations Events
+- **Path**: `['sketch', 'model', 'regulation', 'add']`
+  - **Description**: Add a new regulation.
+  - **Payload**:
+    ```json
+    {
+      "regulator": "string",
+      "target": "string",
+      "sign": "string",
+      "essential": "string"
+    }
+    ```
+- **Path**: `['sketch', 'model', 'regulation', 'remove']`
+  - **Description**: Remove a regulation by specifying regulator and target.
+  - **Payload**:
+    ```json
+    {
+      "regulator": "string",
+      "target": "string"
+    }
+    ```
+
+#### Model Layout Events
+- **Path**: `['sketch', 'model', 'layout', 'add']`
+  - **Description**: Add a new layout with a specified ID and name.
+  - **Payload**:
+    ```json
+    {
+      "layoutId": "string",
+      "name": "string"
+    }
+    ```
+- **Path**: `['sketch', 'model', 'layout', 'remove']`
+  - **Description**: Remove a layout by ID.
+  - **Payload**: `{ "layoutId": "string" }`
+- **Path**: `['sketch', 'model', 'layout', 'update_position']`
+  - **Description**: Update the position of a node in the layout.
+  - **Payload**:
+    ```json
+    {
+      "layoutId": "string",
+      "varId": "string",
+      "px": "number",
+      "py": "number"
+    }
+    ```
+
+---
+
+### Observations and Datasets Events
+
+#### Refresh Events
+
+- **Path**: `['sketch', 'observations', 'refresh']`
+  - **Description**: Refresh all datasets.
+  - **Payload**: None
+- **Path**: `['sketch', 'observations', 'refresh_dataset']`
+  - **Description**: Refresh a single dataset by ID.
+  - **Payload**: `{ "id": "string" }`
+- **Path**: `['sketch', 'observations', 'refresh_observation']`
+  - **Description**: Refresh a single observation in a specified dataset.
+  - **Payload**: `{ "datasetId": "string", "observationId": "string" }`
+
+
+#### Dataset Events
+- **Path**: `['sketch', 'observations', 'add_default']`
+  - **Description**: Add a new empty dataset.
+  - **Payload**: None
+- **Path**: `['sketch', 'observations', 'load']`
+  - **Description**: Load a dataset from a CSV file.
+  - **Payload**: `{ "path": "string" }`
+- **Path**: `['sketch', 'observations', 'remove']`
+  - **Description**: Remove a dataset by ID.
+  - **Payload**: `{ "id": "string" }`
+- **Path**: `['sketch', 'observations', 'set_id']`
+  - **Description**: Update a dataset's ID.
+  - **Payload**: `{ "originalId": "string", "newId": "string" }`
+- **Path**: `['sketch', 'observations', 'set_metadata']`
+  - **Description**: Update the metadata (name, annotation) of a dataset.
+  - **Payload**: `{ "id": "string", "metadata": { "name": "string", "annotation": "string" } }`
+- **Path**: `['sketch', 'observations', 'set_content']`
+  - **Description**: Update the content (variables and observations) of a dataset.
+  - **Payload**: `{ "id": "string", "content": { "variables": [...], "observations": [...] } }`
+- **Path**: `['sketch', 'observations', 'add_var']`
+  - **Description**: Add a placeholder variable to a dataset.
+  - **Payload**: `{ "datasetId": "string" }`
+- **Path**: `['sketch', 'observations', 'remove_var']`
+  - **Description**: Remove a variable from a dataset by ID.
+  - **Payload**: `{ "datasetId": "string", "varId": "string" }`
+- **Path**: `['sketch', 'observations', 'set_var_id']`
+  - **Description**: Update the ID of a variable in a dataset.
+  - **Payload**: `{ "datasetId": "string", "originalId": "string", "newId": "string" }`
+
+#### Observations Events
+- **Path**: `['sketch', 'observations', 'push_obs']`
+  - **Description**: Add a new observation to a dataset.
+  - **Payload**: `{ "datasetId": "string", "observation": { "id": "string", "values": "string" } }`
+- **Path**: `['sketch', 'observations', 'pop_obs']`
+  - **Description**: Remove the last observation from a dataset.
+  - **Payload**: `{ "datasetId": "string" }`
+- **Path**: `['sketch', 'observations', 'remove_obs']`
+  - **Description**: Remove an observation from a dataset.
+  - **Payload**: `{ "datasetId": "string", "observationId": "string" }`
+- **Path**: `['sketch', 'observations', 'set_obs_id']`
+  - **Description**: Update the ID of an observation.
+  - **Payload**: `{ "datasetId": "string", "originalId": "string", "newId": "string" }`
+- **Path**: `['sketch', 'observations', 'set_obs_data']`
+  - **Description**: Update the data of an observation.
+  - **Payload**:
+    ```json
+    {
+      "datasetId": "string",
+      "observation": {
+        "id": "string",
+        "name": "string",
+        "annotation": "string",
+        "values": "string"
+      }
+    }
+    ```
+
+
+---
+
+### Properties Events
+
+#### Refresh Events
+- **Path**: `['sketch', 'properties', 'dynamic', 'refresh']`
+  - **Description**: Refresh all dynamic properties.
+  - **Payload**: None
+- **Path**: `['sketch', 'properties', 'static', 'refresh']`
+  - **Description**: Refresh all static properties.
+  - **Payload**: None
+
+
+#### Dynamic Properties Events
+- **Path**: `['sketch', 'properties', 'dynamic', 'add_default']`
+  - **Description**: Add a new dynamic property of the specified variant.
+  - **Payload**: `{ "variant": "string" }`
+- **Path**: `['sketch', 'properties', 'dynamic', 'remove']`
+  - **Description**: Remove a dynamic property by ID.
+  - **Payload**: `{ "id": "string" }`
+- **Path**: `['sketch', 'properties', 'dynamic', 'set_content']`
+  - **Description**: Update the content of a dynamic property.
+  - **Payload**:
+    ```json
+    {
+      "id": "string",
+      "newContent": {
+        "type": "string",
+        "name": "string",
+        "value": "any"
+      }
+    }
+    ```
+- **Path**: `['sketch', 'properties', 'dynamic', 'set_id']`
+  - **Description**: Update the ID of a dynamic property.
+  - **Payload**: `{ "originalId": "string", "newId": "string" }`
+
+#### Static Properties Events
+- **Path**: `['sketch', 'properties', 'static', 'add_default']`
+  - **Description**: Add a new static property of the specified variant.
+  - **Payload**: `{ "variant": "string" }`
+- **Path**: `['sketch', 'properties', 'static', 'remove']`
+  - **Description**: Remove a static property by ID.
+  - **Payload**: `{ "id": "string" }`
+- **Path**: `['sketch', 'properties', 'static', 'set_content']`
+  - **Description**: Update the content of a static property.
+  - **Payload**:
+    ```json
+    {
+      "id": "string",
+      "newContent": {
+        "type": "string",
+        "name": "string",
+        "value": "any"
+      }
+    }
+    ```
+- **Path**: `['sketch', 'properties', 'static', 'set_id']`
+  - **Description**: Update the ID of a static property.
+  - **Payload**: `{ "originalId": "string", "newId": "string" }`
+
+
+---
+## Analysis Workflow Events
+
+#### State Related Events
+- **Path**: `['analysis', 'refresh_sketch']`
+  - **Description**: Request the current sketch data from the backend.
+  - **Payload**: None
+
+#### Inference Computation Events
+- **Path**: `['analysis', 'start_full_inference']`
+  - **Description**: Start a full inference analysis.
+  - **Payload**: None
+- **Path**: `['analysis', 'start_static_inference']`
+  - **Description**: Start an inference analysis using static properties only.
+  - **Payload**: None
+- **Path**: `['analysis', 'start_dynamic_inference']`
+  - **Description**: Start an inference analysis using dynamic properties only.
+  - **Payload**: None
+- **Path**: `['analysis', 'reset_analysis']`
+  - **Description**: Reset the current analysis and start again using the same sketch.
+  - **Payload**: None
+- **Path**: `['analysis', 'ping_for_results']`
+  - **Description**: Check if inference results are ready.
+  - **Payload**: None
+
+#### Inference Results Events
+- **Path**: `['analysis', 'sample_networks']`
+  - **Description**: Sample Boolean networks from the analysis results.
+  - **Payload**:
+    ```json
+    {
+      "count": "number",
+      "seed": "number|null",
+      "path": "string"
+    }
+    ```
+- **Path**: `['analysis', 'dump_results']`
+  - **Description**: Save the analysis results to a specified path, including the sketch and other related data.
+  - **Payload**: `{ "path": "string" }`
+
+
+---
+## Error Events
+- **Path**: `['error', 'generic']`
+  - **Description**: Receive a generic error message from the backend.
+  - **Payload**:
+    ```json
+    {
+      "message": "string"
+    }
+    ```
+
+
+---
+## New Session Events
+- **Path**: `['new_session', 'create']`
+  - **Description**: Create a new analysis session.
+  - **Payload**: None
+
+---
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "aeon-sketchbook",
+  "name": "biodivine-sketchbook",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "aeon-sketchbook",
+      "name": "biodivine-sketchbook",
       "version": "0.1.0",
       "dependencies": {
         "@floating-ui/dom": "^1.6.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/cytoscape-dagre": "^2.3.3",
         "@types/lodash-es": "^4.17.12",
         "ace-builds": "^1.32.3",
+        "chai": "^5.1.2",
         "cytoscape": "^3.27.0",
         "cytoscape-dagre": "^2.5.0",
         "cytoscape-dblclick": "^0.3.1",
@@ -24,6 +25,8 @@
         "dataclass": "^2.1.1",
         "lit": "^3.1.3",
         "lodash": "^4.17.21",
+        "mocha": "^10.8.2",
+        "selenium-webdriver": "^4.26.0",
         "tabulator-tables": "^5.6.1",
         "uikit": "^3.17.8",
         "uikit-icons": "^0.5.0"
@@ -53,8 +56,15 @@
         "less-loader": "^11.1.3",
         "typescript": "^4.9.5",
         "vite": "^4.5.0",
-        "vite-plugin-top-level-await": "^1.4.1"
+        "vite-plugin-top-level-await": "^1.4.1",
+        "vitest": "^2.1.5"
       }
+    },
+    "node_modules/@bazel/runfiles": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@bazel/runfiles/-/runfiles-6.3.1.tgz",
+      "integrity": "sha512-1uLNT5NZsUVIGS4syuHwTzZ8HycMPyr6POA3FCE4GbMtc4rhoJk8aZKtNIRthJYfL+iioppi+rTfH3olMPr9nA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -709,8 +719,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -1892,6 +1901,92 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.5.tgz",
+      "integrity": "sha512-nZSBTW1XIdpZvEJyoP/Sy8fUg0b8od7ZpGDkTUcfJ7wz/VoZAFzFfLyxVxGFhUjJzhYqSbIpfMtl/+k/dpWa3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.5",
+        "@vitest/utils": "2.1.5",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.5.tgz",
+      "integrity": "sha512-4ZOwtk2bqG5Y6xRGHcveZVr+6txkH7M2e+nPFd6guSoN638v/1XQ0K06eOpi0ptVU/2tW/pIU4IoPotY/GZ9fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.5.tgz",
+      "integrity": "sha512-pKHKy3uaUdh7X6p1pxOkgkVAFW7r2I818vHDthYLvUyjRfkKOU6P45PztOch4DZarWQne+VOaIMwA/erSSpB9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.5",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.5.tgz",
+      "integrity": "sha512-zmYw47mhfdfnYbuhkQvkkzYroXUumrwWDGlMjpdUr4jBd3HZiV2w7CQHj+z7AAS4VOtWxI4Zt4bWt4/sKcoIjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.5",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.5.tgz",
+      "integrity": "sha512-aWZF3P0r3w6DiYTVskOYuhBc7EMc3jvn1TkBg8ttylFFRqNN2XGD7V5a4aQdk6QiUzZQ4klNBSpCLJgWNdIiNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.5.tgz",
+      "integrity": "sha512-yfj6Yrp0Vesw2cwJbP+cl04OC+IHFsuQsrsJBL9pyGeQXE56v1UAOQco+SR55Vf1nQzfV0QJg1Qum7AaWUwwYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.5",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@vituum/vite-plugin-posthtml": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@vituum/vite-plugin-posthtml/-/vite-plugin-posthtml-1.1.0.tgz",
@@ -2156,11 +2251,19 @@
         "ajv": "^6.9.1"
       }
     },
+    "node_modules/ansi-colors": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2170,7 +2273,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2186,7 +2288,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -2200,7 +2301,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-buffer-byte-length": {
@@ -2333,6 +2433,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2353,14 +2462,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2373,7 +2480,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -2383,7 +2489,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -2391,6 +2496,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "license": "ISC"
     },
     "node_modules/browserslist": {
       "version": "4.24.2",
@@ -2457,6 +2568,16 @@
         "semver": "^7.0.0"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
@@ -2487,6 +2608,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001680",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001680.tgz",
@@ -2509,11 +2642,26 @@
       "license": "CC-BY-4.0",
       "peer": true
     },
+    "node_modules/chai": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.2.tgz",
+      "integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2526,11 +2674,19 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -2555,7 +2711,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -2575,11 +2730,21 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2592,7 +2757,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -2622,6 +2786,12 @@
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
       }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.5",
@@ -2773,7 +2943,6 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2785,6 +2954,27 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -2838,6 +3028,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/dir-glob": {
@@ -2942,6 +3141,12 @@
       "dev": true,
       "license": "ISC",
       "peer": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.17.1",
@@ -3074,8 +3279,7 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.4.tgz",
       "integrity": "sha512-MVNK56NiMrOwitFB7cqDwq0CQutbw+0BvLshJSse0MUNU+y1FC3bUS/AQg7oUng+/wKrrki7JfmwtVHkVfPLlw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.0.0",
@@ -3175,9 +3379,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3186,7 +3388,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -3690,6 +3891,23 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/estree-walker/node_modules/@types/estree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3709,6 +3927,16 @@
       "peer": true,
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.1.0.tgz",
+      "integrity": "sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3796,7 +4024,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3809,7 +4036,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -3820,6 +4046,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
       }
     },
     "node_modules/flat-cache": {
@@ -3858,14 +4093,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3913,6 +4146,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -4137,7 +4379,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4211,6 +4452,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
@@ -4269,6 +4519,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -4301,7 +4557,6 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -4312,7 +4567,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -4364,7 +4618,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -4471,17 +4724,24 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -4514,7 +4774,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -4541,6 +4800,15 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4632,6 +4900,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-valid-element-name": {
@@ -4728,7 +5008,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4787,6 +5066,18 @@
       },
       "bin": {
         "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
       }
     },
     "node_modules/keyv": {
@@ -4858,6 +5149,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lit": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
@@ -4904,7 +5204,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -4941,6 +5240,22 @@
       "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
       "license": "MIT"
     },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4951,6 +5266,22 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.2.tgz",
+      "integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.12",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.12.tgz",
+      "integrity": "sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "node_modules/make-dir": {
@@ -5076,11 +5407,92 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/mocha": {
+      "version": "10.8.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
+      "integrity": "sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^4.1.3",
+        "browser-stdout": "^1.3.1",
+        "chokidar": "^3.5.3",
+        "debug": "^4.3.5",
+        "diff": "^5.2.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-up": "^5.0.0",
+        "glob": "^8.1.0",
+        "he": "^1.2.0",
+        "js-yaml": "^4.1.0",
+        "log-symbols": "^4.1.0",
+        "minimatch": "^5.1.6",
+        "ms": "^2.1.3",
+        "serialize-javascript": "^6.0.2",
+        "strip-json-comments": "^3.1.1",
+        "supports-color": "^8.1.1",
+        "workerpool": "^6.5.1",
+        "yargs": "^16.2.0",
+        "yargs-parser": "^20.2.9",
+        "yargs-unparser": "^2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mocha/node_modules/minimatch": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mocha/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -5147,7 +5559,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5260,7 +5671,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -5288,7 +5698,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -5304,7 +5713,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -5315,6 +5723,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -5360,7 +5774,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5403,6 +5816,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -5414,7 +5843,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -5594,6 +6022,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -5648,9 +6082,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -5675,11 +6107,37 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -5705,6 +6163,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/requireindex": {
@@ -5844,7 +6311,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5859,8 +6325,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.3",
@@ -5916,6 +6381,21 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/selenium-webdriver": {
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-4.26.0.tgz",
+      "integrity": "sha512-nA7jMRIPV17mJmAiTDBWN96Sy0Uxrz5CCLb7bLVV6PpL417SyBMPc2Zo/uoREc2EOHlzHwHwAlFtgmSngSY4WQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bazel/runfiles": "^6.3.1",
+        "jszip": "^3.10.1",
+        "tmp": "^0.2.3",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">= 14.21.0"
+      }
+    },
     "node_modules/semver": {
       "version": "7.6.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
@@ -5933,9 +6413,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
       "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -5973,6 +6451,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -6016,6 +6500,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -6056,6 +6547,49 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
+      "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/string.prototype.trim": {
@@ -6114,7 +6648,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6137,7 +6670,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6150,7 +6682,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -6252,11 +6783,63 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.1.tgz",
+      "integrity": "sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
+      "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -6503,6 +7086,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
@@ -6560,6 +7149,799 @@
           "optional": true
         },
         "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.5.tgz",
+      "integrity": "sha512-rd0QIgx74q4S1Rd56XIiL2cYEdyWn13cunYBIuqh9mpmQr7gGS0IxXoP8R6OaZtNQQLyXSWbd4rXKYUbhFpK5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.27.0.tgz",
+      "integrity": "sha512-e312hTjuM89YLqlcqEs7mSvwhxN5pgXqRobUob7Jsz1wDQlpAb2WTX4jzvrx5NrL1h2SE4fGdHSNyPxbLfzyeA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/vite-node/node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.27.0.tgz",
+      "integrity": "sha512-cBUOny8GNXP++gN00Bo5L04I2oqUEFAU0OSDb+4hqp4/R/pZL/zlGzp7lJkhtPX52Rj+PIe0S8aOqhK4hztxHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/vite-node/node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.27.0.tgz",
+      "integrity": "sha512-aauK2M2ptFQQYdOqbKGYCg1LHlPbm6IxepSnHLLaMIGcd9YBiKRGl2+KtzQL/IkurP+b54EKBkvtZaWXijmzfQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/vite-node/node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.27.0.tgz",
+      "integrity": "sha512-VAjOnHUwpvxf3XT33sMpsLGKq24Rz1sTQhLuUicYrV9pxB4TNi0w11qAGPOyR+dQu/iZf88DmEmG0+2Gaqa1gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/vite-node/node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.27.0.tgz",
+      "integrity": "sha512-I2eRlZG87gl6WxP6PvSB5bfFA1btE7tWnG6QAoEU/0Gr47f6KaxRwiRfBujHlzkuMPqtpTlSOW4aOEOyMtQqfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/vite-node/node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.27.0.tgz",
+      "integrity": "sha512-G05JNYFdjikD/2hJTf1gHdD5KjI2TotjiDn17amHtB5JgwrRF1EA9hJ3TRGIvT3zGXilNWWlR71R/2TT1pXRDg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/vite-node/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.27.0.tgz",
+      "integrity": "sha512-FMXxMZ7qnMULwgdmGSFVlOduAhFyqDPoK1A2Q8HBkzGYX9SMFU3ITKfLdIiCzTaaj/pt1OiEbpF2szUw6Kh++Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vite-node/node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.27.0.tgz",
+      "integrity": "sha512-0315TiPsJfOY+jAwEeqxcy9yVcAy/jg99GrMcd/L7CRESzi1vhyLPbnkDnz7giaEttSRf/d3llJYfoC+44Nl3A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vite-node/node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.27.0.tgz",
+      "integrity": "sha512-4zCKY5E9djPyHzvoCWIouFsuAvg+dk+rNia8lz1bjKpzKz02QvK4JPHyjcDT8CFR2J/aA98WccCirdDOy+VDWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vite-node/node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.27.0.tgz",
+      "integrity": "sha512-6St9rrPSLbYBbbJAClpU4gmnO7cdZCMMzx2MT0UCIIIevoLAmsCDOAG6t3J/RgN4CPUpdaGr/UnPqQTHZ4oDwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vite-node/node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.27.0.tgz",
+      "integrity": "sha512-dIBfp8NDrgvwUJxyqFv7501coIba+7xxBJy1gQEF0RGkIKa3Tq0Mh3sF9hmstDLtaMt7gL2aXsCNG9SCKyVVZg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vite-node/node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.27.0.tgz",
+      "integrity": "sha512-Pu7xLHRy+5UjFCKR/vWsbFmiBYUC9993v99YoKWhAgK4VsdNuWHPs17NuCJEtVsZpYCNVPbRyBpQw58Ma8BmeA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vite-node/node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.27.0.tgz",
+      "integrity": "sha512-2Q9qQnk/eWdvXzzHl22y7tpDHREppFUh7N6cCs70HZEbQSgB7wd/2S/B05SSiyAiIn5BL+fYiASLds5bz0IQFw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vite-node/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.27.0.tgz",
+      "integrity": "sha512-CNnqMZ4Yz0Ga0A75qux7DNChq0P9oAWn2S7yjZPRC+AaEF8Ysw5K/1lzT25/a3reJ4V2abcShIVG+tfZHb1UrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vite-node/node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.27.0.tgz",
+      "integrity": "sha512-dS1+eCbbao54XB+wLW6uuwRkChq4L0UfKhd3wvt6s+EN1rTIi24ee5Lk3HfRGq9J2jsRm12/AGKLA0kd82Sp/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vite-node/node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.27.0.tgz",
+      "integrity": "sha512-VrYQHY5+Y71OU/uOSRE9lLhph16bbuWGrMwGwZDPxCUXUW5NgLA+K+q0kv7rafHRlnrsZSVcMOkZskzTNnR3ZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/vite-node/node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.27.0.tgz",
+      "integrity": "sha512-LCqk4Xi3e4GzLqaq+QDM7gP5DtJ/RgWMzV3U2brwp/vEz9RTA5YBgIDP69xYfrTXexes6xPsOIquy79+kLifiA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/vite-node/node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.27.0.tgz",
+      "integrity": "sha512-dj2ZolfViR3chLWwSHID2mBzLLwYvXFldIplR6BSkdACXqAsrcmItKTff4h7enYB3Ugoh0v41WbxijE9HJb1Hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/vite-node/node_modules/@types/estree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/rollup": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.27.0.tgz",
+      "integrity": "sha512-nrOD/RrnAMssruS7bPa7MYpEuH6tUpOa43NLtxQiLKem0An8HZyXun5Ndig6JzbkJoIbaKkt85V67VCaQ59GyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.6"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.27.0",
+        "@rollup/rollup-android-arm64": "4.27.0",
+        "@rollup/rollup-darwin-arm64": "4.27.0",
+        "@rollup/rollup-darwin-x64": "4.27.0",
+        "@rollup/rollup-freebsd-arm64": "4.27.0",
+        "@rollup/rollup-freebsd-x64": "4.27.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.27.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.27.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.27.0",
+        "@rollup/rollup-linux-arm64-musl": "4.27.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.27.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.27.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.27.0",
+        "@rollup/rollup-linux-x64-gnu": "4.27.0",
+        "@rollup/rollup-linux-x64-musl": "4.27.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.27.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.27.0",
+        "@rollup/rollup-win32-x64-msvc": "4.27.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
+      "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
           "optional": true
         },
         "stylus": {
@@ -6670,6 +8052,869 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.5.tgz",
+      "integrity": "sha512-P4ljsdpuzRTPI/kbND2sDZ4VmieerR2c9szEZpjc+98Z9ebvnXmM5+0tHEKqYZumXqlvnmfWsjeFOjXVriDG7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.5",
+        "@vitest/mocker": "2.1.5",
+        "@vitest/pretty-format": "^2.1.5",
+        "@vitest/runner": "2.1.5",
+        "@vitest/snapshot": "2.1.5",
+        "@vitest/spy": "2.1.5",
+        "@vitest/utils": "2.1.5",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.5",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.5",
+        "@vitest/ui": "2.1.5",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.27.0.tgz",
+      "integrity": "sha512-e312hTjuM89YLqlcqEs7mSvwhxN5pgXqRobUob7Jsz1wDQlpAb2WTX4jzvrx5NrL1h2SE4fGdHSNyPxbLfzyeA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/vitest/node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.27.0.tgz",
+      "integrity": "sha512-cBUOny8GNXP++gN00Bo5L04I2oqUEFAU0OSDb+4hqp4/R/pZL/zlGzp7lJkhtPX52Rj+PIe0S8aOqhK4hztxHQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/vitest/node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.27.0.tgz",
+      "integrity": "sha512-aauK2M2ptFQQYdOqbKGYCg1LHlPbm6IxepSnHLLaMIGcd9YBiKRGl2+KtzQL/IkurP+b54EKBkvtZaWXijmzfQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/vitest/node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.27.0.tgz",
+      "integrity": "sha512-VAjOnHUwpvxf3XT33sMpsLGKq24Rz1sTQhLuUicYrV9pxB4TNi0w11qAGPOyR+dQu/iZf88DmEmG0+2Gaqa1gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/vitest/node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.27.0.tgz",
+      "integrity": "sha512-I2eRlZG87gl6WxP6PvSB5bfFA1btE7tWnG6QAoEU/0Gr47f6KaxRwiRfBujHlzkuMPqtpTlSOW4aOEOyMtQqfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/vitest/node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.27.0.tgz",
+      "integrity": "sha512-G05JNYFdjikD/2hJTf1gHdD5KjI2TotjiDn17amHtB5JgwrRF1EA9hJ3TRGIvT3zGXilNWWlR71R/2TT1pXRDg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/vitest/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.27.0.tgz",
+      "integrity": "sha512-FMXxMZ7qnMULwgdmGSFVlOduAhFyqDPoK1A2Q8HBkzGYX9SMFU3ITKfLdIiCzTaaj/pt1OiEbpF2szUw6Kh++Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vitest/node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.27.0.tgz",
+      "integrity": "sha512-0315TiPsJfOY+jAwEeqxcy9yVcAy/jg99GrMcd/L7CRESzi1vhyLPbnkDnz7giaEttSRf/d3llJYfoC+44Nl3A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vitest/node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.27.0.tgz",
+      "integrity": "sha512-4zCKY5E9djPyHzvoCWIouFsuAvg+dk+rNia8lz1bjKpzKz02QvK4JPHyjcDT8CFR2J/aA98WccCirdDOy+VDWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vitest/node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.27.0.tgz",
+      "integrity": "sha512-6St9rrPSLbYBbbJAClpU4gmnO7cdZCMMzx2MT0UCIIIevoLAmsCDOAG6t3J/RgN4CPUpdaGr/UnPqQTHZ4oDwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vitest/node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.27.0.tgz",
+      "integrity": "sha512-dIBfp8NDrgvwUJxyqFv7501coIba+7xxBJy1gQEF0RGkIKa3Tq0Mh3sF9hmstDLtaMt7gL2aXsCNG9SCKyVVZg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vitest/node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.27.0.tgz",
+      "integrity": "sha512-Pu7xLHRy+5UjFCKR/vWsbFmiBYUC9993v99YoKWhAgK4VsdNuWHPs17NuCJEtVsZpYCNVPbRyBpQw58Ma8BmeA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vitest/node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.27.0.tgz",
+      "integrity": "sha512-2Q9qQnk/eWdvXzzHl22y7tpDHREppFUh7N6cCs70HZEbQSgB7wd/2S/B05SSiyAiIn5BL+fYiASLds5bz0IQFw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vitest/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.27.0.tgz",
+      "integrity": "sha512-CNnqMZ4Yz0Ga0A75qux7DNChq0P9oAWn2S7yjZPRC+AaEF8Ysw5K/1lzT25/a3reJ4V2abcShIVG+tfZHb1UrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vitest/node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.27.0.tgz",
+      "integrity": "sha512-dS1+eCbbao54XB+wLW6uuwRkChq4L0UfKhd3wvt6s+EN1rTIi24ee5Lk3HfRGq9J2jsRm12/AGKLA0kd82Sp/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/vitest/node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.27.0.tgz",
+      "integrity": "sha512-VrYQHY5+Y71OU/uOSRE9lLhph16bbuWGrMwGwZDPxCUXUW5NgLA+K+q0kv7rafHRlnrsZSVcMOkZskzTNnR3ZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/vitest/node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.27.0.tgz",
+      "integrity": "sha512-LCqk4Xi3e4GzLqaq+QDM7gP5DtJ/RgWMzV3U2brwp/vEz9RTA5YBgIDP69xYfrTXexes6xPsOIquy79+kLifiA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/vitest/node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.27.0.tgz",
+      "integrity": "sha512-dj2ZolfViR3chLWwSHID2mBzLLwYvXFldIplR6BSkdACXqAsrcmItKTff4h7enYB3Ugoh0v41WbxijE9HJb1Hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/vitest/node_modules/@types/estree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.5.tgz",
+      "integrity": "sha512-XYW6l3UuBmitWqSUXTNXcVBUCRytDogBsWuNXQijc00dtnU/9OqpXWp4OJroVrad/gLIomAq9aW8yWDBtMthhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/rollup": {
+      "version": "4.27.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.27.0.tgz",
+      "integrity": "sha512-nrOD/RrnAMssruS7bPa7MYpEuH6tUpOa43NLtxQiLKem0An8HZyXun5Ndig6JzbkJoIbaKkt85V67VCaQ59GyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.6"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.27.0",
+        "@rollup/rollup-android-arm64": "4.27.0",
+        "@rollup/rollup-darwin-arm64": "4.27.0",
+        "@rollup/rollup-darwin-x64": "4.27.0",
+        "@rollup/rollup-freebsd-arm64": "4.27.0",
+        "@rollup/rollup-freebsd-x64": "4.27.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.27.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.27.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.27.0",
+        "@rollup/rollup-linux-arm64-musl": "4.27.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.27.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.27.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.27.0",
+        "@rollup/rollup-linux-x64-gnu": "4.27.0",
+        "@rollup/rollup-linux-x64-musl": "4.27.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.27.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.27.0",
+        "@rollup/rollup-win32-x64-msvc": "4.27.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
+      "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
       }
     },
     "node_modules/vituum": {
@@ -7367,6 +9612,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -7377,18 +9639,111 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/workerpool": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
+      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,12 +39,12 @@
         "@types/cytoscape-popper": "^2.0.4",
         "@types/lodash": "^4.14.202",
         "@types/node": "^20.11.19",
-        "@types/rollup-plugin-less": "^1.1.4",
         "@types/tabulator-tables": "^5.5.10",
         "@types/uikit": "^3.14.0",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
         "@typescript-eslint/parser": "^6.9.1",
         "@vituum/vite-plugin-posthtml": "^1.0.0",
+        "@wcj/rollup-plugin-less": "^2.0.0",
         "eslint": "^8.55.0",
         "eslint-config-standard-with-typescript": "^39.1.1",
         "eslint-plugin-import": "^2.29.0",
@@ -810,6 +810,56 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.3.tgz",
+      "integrity": "sha512-Pnsb6f32CD2W3uCaLZIzDmeFyQ2b8UWMFI7xtwUezpcGBDVDW6y9XgAWIlARiGAo6eNF5FK5aQTr0LFyNyqq5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/@types/estree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1586,7 +1636,8 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -1599,13 +1650,6 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/less": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/less/-/less-3.0.6.tgz",
-      "integrity": "sha512-PecSzorDGdabF57OBeQO/xFbAkYWo88g4Xvnsx7LRwqLC17I7OoKtA3bQB9uXkY6UkMWCOsA8HSVpaoitscdXw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1649,18 +1693,6 @@
         "@types/prop-types": "*",
         "@types/scheduler": "^0.16",
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/rollup-plugin-less": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@types/rollup-plugin-less/-/rollup-plugin-less-1.1.5.tgz",
-      "integrity": "sha512-m4BDbs04cztW16Hc1+AoUz8Iox58Vz2PUuPKccc3vJ2H1oIPRk3IPT2llBPPcSfsOyObATYs6PHduWaaw/24Lw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/less": "*",
-        "@types/node": "*",
-        "rollup": "^0.63.4"
       }
     },
     "node_modules/@types/scheduler": {
@@ -2000,6 +2032,24 @@
       },
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/@wcj/rollup-plugin-less": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@wcj/rollup-plugin-less/-/rollup-plugin-less-2.0.0.tgz",
+      "integrity": "sha512-jNuhjQBTOuMd1Rjr071aWOVHC3/WX5DAxzdQwruP7cabazCDBznxdbkn/ftBezuwRyGzn0bEdCZCZxIGKxOCAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.2",
+        "fs-extra": "^11.1.1",
+        "less": "^4.1.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.0.0||^3.0.0"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -4089,6 +4139,21 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5066,6 +5131,19 @@
       },
       "bin": {
         "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jszip": {
@@ -6251,17 +6329,20 @@
       }
     },
     "node_modules/rollup": {
-      "version": "0.63.5",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.63.5.tgz",
-      "integrity": "sha512-dFf8LpUNzIj3oE0vCvobX6rqOzHzLBoblyFp+3znPbjiSmSvOoK2kMKx+Fv9jYduG1rvcCfCveSgEaQHjWRF6g==",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/estree": "0.0.39",
-        "@types/node": "*"
-      },
       "bin": {
-        "rollup": "bin/rollup"
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/run-parallel": {
@@ -7036,6 +7117,16 @@
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",
@@ -8034,23 +8125,6 @@
         "@rollup/rollup-win32-arm64-msvc": "4.26.0",
         "@rollup/rollup-win32-ia32-msvc": "4.26.0",
         "@rollup/rollup-win32-x64-msvc": "4.26.0",
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/vite/node_modules/rollup": {
-      "version": "3.29.5",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
-      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=14.18.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/cytoscape-popper": "^2.0.4",
     "@types/lodash": "^4.14.202",
     "@types/node": "^20.11.19",
-    "@types/rollup-plugin-less": "^1.1.4",
+    "@wcj/rollup-plugin-less": "^2.0.0",
     "@types/tabulator-tables": "^5.5.10",
     "@types/uikit": "^3.14.0",
     "@typescript-eslint/eslint-plugin": "^6.9.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "test": "vitest"
   },
   "dependencies": {
     "@floating-ui/dom": "^1.6.4",
@@ -18,6 +19,7 @@
     "@types/cytoscape-dagre": "^2.3.3",
     "@types/lodash-es": "^4.17.12",
     "ace-builds": "^1.32.3",
+    "chai": "^5.1.2",
     "cytoscape": "^3.27.0",
     "cytoscape-dagre": "^2.5.0",
     "cytoscape-dblclick": "^0.3.1",
@@ -26,6 +28,8 @@
     "dataclass": "^2.1.1",
     "lit": "^3.1.3",
     "lodash": "^4.17.21",
+    "mocha": "^10.8.2",
+    "selenium-webdriver": "^4.26.0",
     "tabulator-tables": "^5.6.1",
     "uikit": "^3.17.8",
     "uikit-icons": "^0.5.0"
@@ -55,6 +59,7 @@
     "less-loader": "^11.1.3",
     "typescript": "^4.9.5",
     "vite": "^4.5.0",
-    "vite-plugin-top-level-await": "^1.4.1"
+    "vite-plugin-top-level-await": "^1.4.1",
+    "vitest": "^2.1.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "aeon-sketchbook",
+  "name": "biodivine-sketchbook",
   "private": true,
   "version": "0.1.0",
   "type": "module",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "aeon-sketchbook"
+name = "biodivine-sketchbook"
 version = "0.1.0"
 description = "A multi-platform application for designing and analysing large-scale logical models."
 authors = ["Ondrej Huvar <xhuvar@fi.muni.cz>", "Samuel Pastva <sam.pastva@gmail.com>", "Petr Ivicic"]
 license = "MIT"
-repository = "https://github.com/sybila/biodivine-aeon-sketchbook"
+repository = "https://github.com/sybila/biodivine-sketchbook"
 edition = "2021"
 readme = "README.md"
 

--- a/src-tauri/src/algorithms/eval_dynamic/eval.rs
+++ b/src-tauri/src/algorithms/eval_dynamic/eval.rs
@@ -50,7 +50,7 @@ pub fn eval_dyn_prop(
                 let unit_bdd = sat_colors.as_bdd();
                 let original_context = graph.symbolic_context();
                 let (space_ctx, space_graph) =
-                    get_ts_extended_symbolic_graph(bn, Some((&unit_bdd, &original_context)))?;
+                    get_ts_extended_symbolic_graph(bn, Some((unit_bdd, original_context)))?;
 
                 let observations = prop.dataset.observations().clone();
                 let var_names = prop.dataset.variable_names();

--- a/src-tauri/src/analysis/inference_solver.rs
+++ b/src-tauri/src/analysis/inference_solver.rs
@@ -72,7 +72,6 @@ pub struct FinishedInferenceSolver {
     pub bn: BooleanNetwork,
     pub graph: SymbolicAsyncGraph,
     pub sat_colors: GraphColors,
-    pub status_updates: Vec<InferenceStatusReport>,
     pub results: InferenceResults,
 }
 
@@ -288,7 +287,6 @@ impl InferenceSolver {
                 bn: self.bn.clone().unwrap(),
                 graph: self.graph.clone().unwrap(),
                 sat_colors: self.raw_sat_colors.clone().unwrap(),
-                status_updates: self.status_updates.clone(),
                 results: self.results.clone().unwrap(),
             }),
             InferenceStatus::Error => {

--- a/src-tauri/src/analysis/results_export.rs
+++ b/src-tauri/src/analysis/results_export.rs
@@ -119,14 +119,8 @@ fn format_inference_results(results: &InferenceResults) -> String {
     output.push_str("Detailed progress report:\n");
     output.push_str("--------------\n");
     for report in &results.progress_statuses {
-        let report_line = match report.num_candidates {
-            Some(candidates) => format!(
-                "> {}ms: {} ({} candidates)\n",
-                report.comp_time, report.message, candidates
-            ),
-            None => format!("> {}ms: {}\n", report.comp_time, report.message),
-        };
-        output.push_str(&report_line);
+        output.push_str(&report.message);
+        output.push('\n');
     }
 
     output

--- a/src-tauri/src/app/_aeon_error.rs
+++ b/src-tauri/src/app/_aeon_error.rs
@@ -16,7 +16,7 @@ impl AeonError {
     /// Refer to [Error] regarding recommended error description format.
     ///
     /// ```rust
-    /// # use aeon_sketchbook::app::AeonError;
+    /// # use biodivine_sketchbook::app::AeonError;
     /// # use std::error::Error;
     /// let error = AeonError::new("something failed", None);
     /// let other_error = AeonError::new("something else failed", Some(Box::new(error)));
@@ -45,7 +45,7 @@ impl AeonError {
     /// See also [AeonError::throw_with_source].
     ///
     /// ```rust
-    /// # use aeon_sketchbook::app::{AeonError, DynError};
+    /// # use biodivine_sketchbook::app::{AeonError, DynError};
     /// fn division(numerator: i32, denominator: i32) -> Result<i32, DynError> {
     ///     if denominator == 0 {
     ///         AeonError::throw("division by zero")
@@ -68,7 +68,7 @@ impl AeonError {
     /// (see the example below).
     ///
     /// ```rust
-    /// # use aeon_sketchbook::app::{AeonError, DynError};
+    /// # use biodivine_sketchbook::app::{AeonError, DynError};
     /// fn read_number(num: &str) -> Result<i32, DynError> {
     ///     match num.parse::<i32>() {
     ///         Ok(num) => Ok(num),

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,15 +1,15 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-use aeon_sketchbook::app::event::{Event, SessionMessage, StateChange, UserAction};
-use aeon_sketchbook::app::event_wrappers::{AeonAction, AeonMessage, AeonRefresh};
-use aeon_sketchbook::app::state::analysis::AnalysisSession;
-use aeon_sketchbook::app::state::editor::EditorSession;
-use aeon_sketchbook::app::state::{AppState, DynSession};
-use aeon_sketchbook::app::{
+use biodivine_sketchbook::app::event::{Event, SessionMessage, StateChange, UserAction};
+use biodivine_sketchbook::app::event_wrappers::{AeonAction, AeonMessage, AeonRefresh};
+use biodivine_sketchbook::app::state::analysis::AnalysisSession;
+use biodivine_sketchbook::app::state::editor::EditorSession;
+use biodivine_sketchbook::app::state::{AppState, DynSession};
+use biodivine_sketchbook::app::{
     AeonApp, AEON_ACTION, AEON_MESSAGE, AEON_REFRESH, DEFAULT_SESSION_ID, DEFAULT_WINDOW_ID,
 };
-use aeon_sketchbook::debug;
+use biodivine_sketchbook::debug;
 use chrono::prelude::*;
 use tauri::{command, Manager, State, Window};
 

--- a/src-tauri/src/sketchbook/mod.rs
+++ b/src-tauri/src/sketchbook/mod.rs
@@ -110,7 +110,7 @@ pub trait Manager {
 
         // finally, try searching for a valid number to append at the end of the id
         // start searching at index 1 (or start-index), until we try `max_idx` options
-        let start_index = if let Some(i) = start_index { i } else { 1 };
+        let start_index = start_index.unwrap_or(1);
         let last_index = start_index + num_indices;
         for n in start_index..last_index {
             let id = T::from_str(format!("{}_{}", transformed_id, n).as_str()).unwrap();

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_layout.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_layout.rs
@@ -8,6 +8,15 @@ use crate::sketchbook::layout::NodePosition;
 use crate::sketchbook::model::ModelState;
 use crate::sketchbook::JsonSerde;
 
+/* Constants for event path segments in `ModelState` related to layout events. */
+
+// add whole new layout
+const ADD_LAYOUT_PATH: &str = "add";
+// update position of a node in a particular layout
+const UPDATE_POSITION_PATH: &str = "update_position";
+// remove whole layout
+const REMOVE_LAYOUT_PATH: &str = "remove";
+
 /// Implementation for events related to `layouts` of the model.
 impl ModelState {
     /// Perform events related to `layouts` component of this `ModelState`.
@@ -22,7 +31,7 @@ impl ModelState {
         // when adding new layout, the `at_path` is just ["add"]
         // when editing existing layout, the `at_path` is ["layout_id", "<action>"]
 
-        if Self::starts_with("add", at_path).is_some() {
+        if Self::starts_with(ADD_LAYOUT_PATH, at_path).is_some() {
             Self::assert_path_length(at_path, 1, component_name)?;
             self.event_add_layout(event)
         } else {
@@ -64,7 +73,7 @@ impl ModelState {
     ) -> Result<Consumed, DynError> {
         let component_name = "model/layout";
 
-        if Self::starts_with("update_position", at_path).is_some() {
+        if Self::starts_with(UPDATE_POSITION_PATH, at_path).is_some() {
             // get payload components (json containing "var_id", "new_x" and "new_y")
             let payload = Self::clone_payload_str(event, component_name)?;
             let new_node_data = LayoutNodeData::from_json_str(payload.as_str())?;
@@ -93,7 +102,7 @@ impl ModelState {
             let mut reverse_event = event.clone();
             reverse_event.payload = Some(orig_pos_data.to_json_str());
             Ok(make_reversible(state_change, event, reverse_event))
-        } else if Self::starts_with("remove", at_path).is_some() {
+        } else if Self::starts_with(REMOVE_LAYOUT_PATH, at_path).is_some() {
             Self::assert_payload_empty(event, component_name)?;
 
             let layout = self.get_layout(&layout_id)?;

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_regulations.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_regulations.rs
@@ -11,6 +11,25 @@ use crate::sketchbook::properties::shortcuts::*;
 use crate::sketchbook::properties::StatProperty;
 use crate::sketchbook::JsonSerde;
 
+/* Constants for event path segments in `ModelState` related to regulations. */
+
+// add new regulation, including changes in static properties
+const ADD_REGULATION_PATH: &str = "add";
+// add new regulation (without additional changes)
+const ADD_RAW_REGULATION_PATH: &str = "add_raw";
+// remove regulation, including changes in static properties
+const REMOVE_REGULATION_PATH: &str = "remove";
+// remove regulation (without additional changes)
+const REMOVE_RAW_REGULATION_PATH: &str = "remove_raw";
+// set regulation's sign, including changes in static properties
+const SET_SIGN_PATH: &str = "set_sign";
+// set regulation's sign (without additional changes)
+const SET_SIGN_RAW_PATH: &str = "set_sign_raw";
+// set regulation's essentiality, including changes in static properties
+const SET_ESSENTIALITY_PATH: &str = "set_essentiality";
+// set regulation's essentiality (without additional changes)
+const SET_ESSENTIALITY_RAW_PATH: &str = "set_essentiality_raw";
+
 /// Implementation for events related to `regulations` of the model.
 impl ModelState {
     /// Perform events related to `regulations` component of this `ModelState`.
@@ -25,10 +44,10 @@ impl ModelState {
         // when adding new regulation, the `at_path` is just ["add"]
         // when editing existing variable, the `at_path` is ["regulator", "target", "<action>"]
 
-        if Self::starts_with("add", at_path).is_some() {
+        if Self::starts_with(ADD_REGULATION_PATH, at_path).is_some() {
             Self::assert_path_length(at_path, 1, component_name)?;
             self.event_add_regulation(event)
-        } else if Self::starts_with("add_raw", at_path).is_some() {
+        } else if Self::starts_with(ADD_RAW_REGULATION_PATH, at_path).is_some() {
             Self::assert_path_length(at_path, 1, component_name)?;
             self.event_add_regulation_raw(event)
         } else {
@@ -122,7 +141,7 @@ impl ModelState {
     ) -> Result<Consumed, DynError> {
         let component_name = "model/regulation";
 
-        if Self::starts_with("remove", at_path).is_some() {
+        if Self::starts_with(REMOVE_REGULATION_PATH, at_path).is_some() {
             let mut event_list = Vec::new();
             // the event of removing the raw regulation itself
             let reg_event_path = [
@@ -151,7 +170,7 @@ impl ModelState {
                 event_list.push(prop_event);
             }
             Ok(Consumed::Restart(event_list))
-        } else if Self::starts_with("remove_raw", at_path).is_some() {
+        } else if Self::starts_with(REMOVE_RAW_REGULATION_PATH, at_path).is_some() {
             Self::assert_payload_empty(event, component_name)?;
 
             // save the original regulation data for state change and reverse event
@@ -167,7 +186,7 @@ impl ModelState {
             let payload = reg_data.to_json_str();
             let reverse_event = mk_model_event(&reverse_at_path, Some(&payload));
             Ok(make_reversible(state_change, event, reverse_event))
-        } else if Self::starts_with("set_sign", at_path).is_some() {
+        } else if Self::starts_with(SET_SIGN_PATH, at_path).is_some() {
             // get the payload - a string for the "new_sign"
             let sign_str = Self::clone_payload_str(event, component_name)?;
             let new_sign = Monotonicity::from_json_str(&sign_str)?;
@@ -214,7 +233,7 @@ impl ModelState {
             }
 
             Ok(Consumed::Restart(event_list))
-        } else if Self::starts_with("set_sign_raw", at_path).is_some() {
+        } else if Self::starts_with(SET_SIGN_RAW_PATH, at_path).is_some() {
             // get the payload - a string for the "new_sign"
             let sign_str = Self::clone_payload_str(event, component_name)?;
             let new_sign = Monotonicity::from_json_str(&sign_str)?;
@@ -236,7 +255,7 @@ impl ModelState {
             let mut reverse_event = event.clone();
             reverse_event.payload = Some(orig_sign.to_json_str());
             Ok(make_reversible(state_change, event, reverse_event))
-        } else if Self::starts_with("set_essentiality", at_path).is_some() {
+        } else if Self::starts_with(SET_ESSENTIALITY_PATH, at_path).is_some() {
             // get the payload - a string for the "new_essentiality"
             let essentiality_str = Self::clone_payload_str(event, component_name)?;
             let new_essentiality = Essentiality::from_json_str(&essentiality_str)?;
@@ -283,7 +302,7 @@ impl ModelState {
             }
 
             Ok(Consumed::Restart(event_list))
-        } else if Self::starts_with("set_essentiality_raw", at_path).is_some() {
+        } else if Self::starts_with(SET_ESSENTIALITY_RAW_PATH, at_path).is_some() {
             // get the payload - a string for the "new_essentiality"
             let essentiality_str = Self::clone_payload_str(event, component_name)?;
             let new_essentiality = Essentiality::from_json_str(&essentiality_str)?;

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_regulations.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_regulations.rs
@@ -41,7 +41,7 @@ impl ModelState {
         let component_name = "model/regulation";
 
         // there is either adding of a new regulation, or editing/removing of an existing one
-        // when adding new regulation, the `at_path` is just ["add"]
+        // when adding new regulation, the `at_path` is just ["add"] or ["add_raw"]
         // when editing existing variable, the `at_path` is ["regulator", "target", "<action>"]
 
         if Self::starts_with(ADD_REGULATION_PATH, at_path).is_some() {

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_uninterpreted_fns.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_uninterpreted_fns.rs
@@ -45,7 +45,7 @@ impl ModelState {
         let component_name = "model/uninterpreted_fn";
 
         // there is either adding of a new uninterpreted_fn, or editing/removing of an existing one
-        // when adding new uninterpreted fn, the `at_path` is just ["add"]
+        // when adding new uninterpreted fn, the `at_path` is just ["add"] or ["add_default"]
         // when editing existing uninterpreted fn, the `at_path` is ["fn_id", "<action>"]
 
         if Self::starts_with(ADD_DEFAULT_FN_PATH, at_path).is_some() {

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_uninterpreted_fns.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_uninterpreted_fns.rs
@@ -9,6 +9,31 @@ use crate::sketchbook::ids::UninterpretedFnId;
 use crate::sketchbook::model::{ModelState, UninterpretedFn};
 use crate::sketchbook::JsonSerde;
 
+/* Constants for event path segments in `ModelState` related to uninterpreted functions. */
+
+// add new prepared function
+const ADD_FN_PATH: &str = "add";
+// add new default function
+const ADD_DEFAULT_FN_PATH: &str = "add_default";
+// remove particular function
+const REMOVE_FN_PATH: &str = "remove";
+// set function's raw data
+const SET_DATA_PATH: &str = "set_data";
+// set function's ID
+const SET_ID_PATH: &str = "set_id";
+// set function's arity
+const SET_ARITY_PATH: &str = "set_arity";
+// increment function's arity
+const INCREMENT_ARITY_PATH: &str = "increment_arity";
+// decrement function's arity
+const DECREMENT_ARITY_PATH: &str = "decrement_arity";
+// set function's expression
+const SET_EXPRESSION_PATH: &str = "set_expression";
+// set monotonicity of function with respect to its argument
+const SET_MONOTONICITY_PATH: &str = "set_monotonicity";
+// set essentiality of function with respect to its argument
+const SET_ESSENTIALITY_PATH: &str = "set_essentiality";
+
 /// Implementation for events related to `uninterpreted functions` of the model.
 impl ModelState {
     /// Perform events related to `uninterpreted fns` component of this `ModelState`.
@@ -23,10 +48,10 @@ impl ModelState {
         // when adding new uninterpreted fn, the `at_path` is just ["add"]
         // when editing existing uninterpreted fn, the `at_path` is ["fn_id", "<action>"]
 
-        if Self::starts_with("add_default", at_path).is_some() {
+        if Self::starts_with(ADD_DEFAULT_FN_PATH, at_path).is_some() {
             Self::assert_path_length(at_path, 1, component_name)?;
             self.event_add_default_uninterpreted_fn(event)
-        } else if Self::starts_with("add", at_path).is_some() {
+        } else if Self::starts_with(ADD_FN_PATH, at_path).is_some() {
             Self::assert_path_length(at_path, 1, component_name)?;
             self.event_add_uninterpreted_fn(event)
         } else {
@@ -99,7 +124,7 @@ impl ModelState {
     ) -> Result<Consumed, DynError> {
         let component_name = "model/uninterpreted_fn";
 
-        if Self::starts_with("remove", at_path).is_some() {
+        if Self::starts_with(REMOVE_FN_PATH, at_path).is_some() {
             // check that payload is really empty
             if event.payload.is_some() {
                 let message = "Payload must be empty for uninterpreted fn removing.".to_string();
@@ -117,7 +142,7 @@ impl ModelState {
             let payload = fn_data.to_json_str();
             let reverse_event = mk_model_event(&reverse_at_path, Some(&payload));
             Ok(make_reversible(state_change, event, reverse_event))
-        } else if Self::starts_with("set_data", at_path).is_some() {
+        } else if Self::starts_with(SET_DATA_PATH, at_path).is_some() {
             // get the payload - string with modified function data
             let payload = Self::clone_payload_str(event, component_name)?;
             let new_data = UninterpretedFnData::from_json_str(&payload)?;
@@ -138,7 +163,7 @@ impl ModelState {
             let mut reverse_event = event.clone();
             reverse_event.payload = Some(original_data.to_json_str());
             Ok(make_reversible(state_change, event, reverse_event))
-        } else if Self::starts_with("set_id", at_path).is_some() {
+        } else if Self::starts_with(SET_ID_PATH, at_path).is_some() {
             // get the payload - string for "new_id"
             let new_id = Self::clone_payload_str(event, component_name)?;
             if fn_id.as_str() == new_id.as_str() {
@@ -157,7 +182,7 @@ impl ModelState {
             let reverse_at_path = ["uninterpreted_fn", new_id.as_str(), "set_id"];
             let reverse_event = mk_model_event(&reverse_at_path, Some(fn_id.as_str()));
             Ok(make_reversible(state_change, event, reverse_event))
-        } else if Self::starts_with("set_arity", at_path).is_some() {
+        } else if Self::starts_with(SET_ARITY_PATH, at_path).is_some() {
             // get the payload - string for "new_arity"
             let new_arity: usize = Self::clone_payload_str(event, component_name)?.parse()?;
             let original_arity = self.get_uninterpreted_fn(&fn_id)?.get_arity();
@@ -174,7 +199,7 @@ impl ModelState {
             let mut reverse_event = event.clone();
             reverse_event.payload = Some(original_arity.to_string());
             Ok(make_reversible(state_change, event, reverse_event))
-        } else if Self::starts_with("increment_arity", at_path).is_some() {
+        } else if Self::starts_with(INCREMENT_ARITY_PATH, at_path).is_some() {
             Self::assert_payload_empty(event, component_name)?;
 
             // perform the event, prepare the state-change variant (move id from path to payload)
@@ -187,7 +212,7 @@ impl ModelState {
             let reverse_at_path = ["uninterpreted_fn", fn_id.as_str(), "decrement_arity"];
             let reverse_event = mk_model_event(&reverse_at_path, None);
             Ok(make_reversible(state_change, event, reverse_event))
-        } else if Self::starts_with("decrement_arity", at_path).is_some() {
+        } else if Self::starts_with(DECREMENT_ARITY_PATH, at_path).is_some() {
             Self::assert_payload_empty(event, component_name)?;
 
             // perform the event, prepare the state-change variant (move id from path to payload)
@@ -200,7 +225,7 @@ impl ModelState {
             let reverse_at_path = ["uninterpreted_fn", fn_id.as_str(), "increment_arity"];
             let reverse_event = mk_model_event(&reverse_at_path, None);
             Ok(make_reversible(state_change, event, reverse_event))
-        } else if Self::starts_with("set_expression", at_path).is_some() {
+        } else if Self::starts_with(SET_EXPRESSION_PATH, at_path).is_some() {
             // get the payload - string for "expression"
             let new_expression = Self::clone_payload_str(event, component_name)?;
             let original_expression = self
@@ -226,7 +251,7 @@ impl ModelState {
             let mut reverse_event = event.clone();
             reverse_event.payload = Some(original_expression);
             Ok(make_reversible(state_change, event, reverse_event))
-        } else if Self::starts_with("set_monotonicity", at_path).is_some() {
+        } else if Self::starts_with(SET_MONOTONICITY_PATH, at_path).is_some() {
             // get the payload and parse it
             let payload = Self::clone_payload_str(event, component_name)?;
             let change_data = ChangeArgMonotoneData::from_json_str(payload.as_str())?;
@@ -252,7 +277,7 @@ impl ModelState {
             let reverse_change = ChangeArgMonotoneData::new(change_data.idx, original_monotonicity);
             reverse_event.payload = Some(reverse_change.to_json_str());
             Ok(make_reversible(state_change, event, reverse_event))
-        } else if Self::starts_with("set_essentiality", at_path).is_some() {
+        } else if Self::starts_with(SET_ESSENTIALITY_PATH, at_path).is_some() {
             // get the payload and parse it
             let payload = Self::clone_payload_str(event, component_name)?;
             let change_data = ChangeArgEssentialData::from_json_str(payload.as_str())?;

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_variables.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_variables.rs
@@ -10,6 +10,23 @@ use crate::sketchbook::layout::NodePosition;
 use crate::sketchbook::model::{ModelState, UpdateFn, Variable};
 use crate::sketchbook::JsonSerde;
 
+/* Constants for event path segments in `ModelState` related to variables. */
+
+// add new propared variable (and potentially change its position)
+const ADD_VAR_PATH: &str = "add";
+// add new default variable
+const ADD_DEFAULT_VAR_PATH: &str = "add_default";
+// add new variable (without any additional changes)
+const ADD_RAW_VAR_PATH: &str = "add_raw";
+// remove variable (removing all its regulations and so on)
+const REMOVE_VAR_PATH: &str = "remove";
+// set variable's data (name and annotation)
+const SET_DATA_PATH: &str = "set_data";
+// set variable's id
+const SET_ID_PATH: &str = "set_id";
+// set variable's update fn
+const SET_UPDATE_FN_PATH: &str = "set_update_fn";
+
 /// Implementation for events related to `variables` of the model.
 impl ModelState {
     /// Perform events related to `variables` component of this `ModelState`.
@@ -26,17 +43,17 @@ impl ModelState {
 
         // adding default version of variable (automatically generated ID, name, empty function)
         // also handles the positioning of the variable
-        if Self::starts_with("add_default", at_path).is_some() {
+        if Self::starts_with(ADD_DEFAULT_VAR_PATH, at_path).is_some() {
             Self::assert_path_length(at_path, 1, component_name)?;
             self.event_add_default_variable(event)
         // raw event of adding variable, atomic (no event restart with re-positioning sub-events
         // or anything like that)
-        } else if Self::starts_with("add_raw", at_path).is_some() {
+        } else if Self::starts_with(ADD_RAW_VAR_PATH, at_path).is_some() {
             Self::assert_path_length(at_path, 1, component_name)?;
             self.event_add_variable_raw(event)
         // adding variable with all sub-fields given in the event
         // also handles the positioning of the variable
-        } else if Self::starts_with("add", at_path).is_some() {
+        } else if Self::starts_with(ADD_VAR_PATH, at_path).is_some() {
             Self::assert_path_length(at_path, 1, component_name)?;
             self.event_add_variable(event)
         } else {
@@ -162,7 +179,7 @@ impl ModelState {
     ) -> Result<Consumed, DynError> {
         let component_name = "model/variable";
 
-        if Self::starts_with("remove", at_path).is_some() {
+        if Self::starts_with(REMOVE_VAR_PATH, at_path).is_some() {
             Self::assert_payload_empty(event, component_name)?;
 
             // First step - check that variable can be safely deleted, i.e., it is not contained in
@@ -226,7 +243,7 @@ impl ModelState {
                 }
                 Ok(Consumed::Restart(event_list))
             }
-        } else if Self::starts_with("set_data", at_path).is_some() {
+        } else if Self::starts_with(SET_DATA_PATH, at_path).is_some() {
             // get the payload - string with modified variable data
             let payload = Self::clone_payload_str(event, component_name)?;
             let new_data = VariableData::from_json_str(&payload)?;
@@ -248,7 +265,7 @@ impl ModelState {
             let mut reverse_event = event.clone();
             reverse_event.payload = Some(original_data.to_json_str());
             Ok(make_reversible(state_change, event, reverse_event))
-        } else if Self::starts_with("set_id", at_path).is_some() {
+        } else if Self::starts_with(SET_ID_PATH, at_path).is_some() {
             // get the payload - string for "new_id"
             let new_id = Self::clone_payload_str(event, component_name)?;
             if var_id.as_str() == new_id.as_str() {
@@ -267,7 +284,7 @@ impl ModelState {
             let reverse_at_path = ["variable", new_id.as_str(), "set_id"];
             let reverse_event = mk_model_event(&reverse_at_path, Some(var_id.as_str()));
             Ok(make_reversible(state_change, event, reverse_event))
-        } else if Self::starts_with("set_update_fn", at_path).is_some() {
+        } else if Self::starts_with(SET_UPDATE_FN_PATH, at_path).is_some() {
             // get the payload - string for "new_expression"
             let new_expression = Self::clone_payload_str(event, component_name)?;
             let original_expression = self.get_update_fn(&var_id)?.to_string();

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_variables.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_variables.rs
@@ -38,7 +38,7 @@ impl ModelState {
         let component_name = "model/variable";
 
         // there is either adding of a new variable, or editing/removing of an existing one
-        // when adding new variable, the `at_path` is just ["add"] or ["add_default"]
+        // when adding new variable, the `at_path` is just ["add"], ["add_default"] or ["add_raw"]
         // when editing existing variable, the `at_path` is ["var_id", "<action>"]
 
         // adding default version of variable (automatically generated ID, name, empty function)

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/mod.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/mod.rs
@@ -15,27 +15,53 @@ pub mod _events_variables;
 /// **(internal)** Implementation for `refresh` (getter) events.
 pub mod _refresh_events;
 
+/* Constants for event path segments in `ModelState` for event handling. */
+
+// events being delegated to `variables` subcomponent
+const VAR_EVENT_PATH: &str = "variable";
+// events being delegated to `uninterpreted fns` subcomponent
+const FN_EVENT_PATH: &str = "uninterpreted_fn";
+// events being delegated to `regulations` subcomponent
+const REGULATION_EVENT_PATH: &str = "regulation";
+// events being delegated to `layouts` subcomponent
+const LAYOUT_EVENT_PATH: &str = "layout";
+
+/* Constants for refresh event path segments in `ModelState` for retrieving data. */
+
+// refresh all model components at once
+const REFRESH_MODEL_PATH: &str = "get_whole_model";
+// refresh all model variables
+const REFRESH_VARS_PATH: &str = "get_variables";
+// refresh all model uninterpreted fns
+const REFRESH_FNS_PATH: &str = "get_uninterpreted_fns";
+// refresh all model regulations
+const REFRESH_REGULATIONS_PATH: &str = "get_regulations";
+// refresh all model layouts
+const REFRESH_LAYOUTS_PATH: &str = "get_layouts";
+// refresh all nodes in a particular layout
+const REFRESH_LAYOUT_NODES_PATH: &str = "get_layout_nodes";
+
 impl SessionHelper for ModelState {}
 
 impl SessionState for ModelState {
     fn perform_event(&mut self, event: &Event, at_path: &[&str]) -> Result<Consumed, DynError> {
         match at_path.first() {
-            Some(&"variable") => self.perform_variable_event(event, &at_path[1..]),
-            Some(&"uninterpreted_fn") => self.perform_uninterpreted_fn_event(event, &at_path[1..]),
-            Some(&"regulation") => self.perform_regulation_event(event, &at_path[1..]),
-            Some(&"layout") => self.perform_layout_event(event, &at_path[1..]),
+            Some(&VAR_EVENT_PATH) => self.perform_variable_event(event, &at_path[1..]),
+            Some(&FN_EVENT_PATH) => self.perform_uninterpreted_fn_event(event, &at_path[1..]),
+            Some(&REGULATION_EVENT_PATH) => self.perform_regulation_event(event, &at_path[1..]),
+            Some(&LAYOUT_EVENT_PATH) => self.perform_layout_event(event, &at_path[1..]),
             _ => Self::invalid_path_error_generic(at_path),
         }
     }
 
     fn refresh(&self, full_path: &[String], at_path: &[&str]) -> Result<Event, DynError> {
         match at_path.first() {
-            Some(&"get_whole_model") => self.refresh_whole_model(full_path),
-            Some(&"get_variables") => self.refresh_variables(full_path),
-            Some(&"get_uninterpreted_fns") => self.refresh_uninterpreted_fns(full_path),
-            Some(&"get_regulations") => self.refresh_regulations(full_path),
-            Some(&"get_layouts") => self.refresh_layouts(full_path),
-            Some(&"get_layout_nodes") => self.refresh_layout_nodes(full_path, &at_path[1..]),
+            Some(&REFRESH_MODEL_PATH) => self.refresh_whole_model(full_path),
+            Some(&REFRESH_VARS_PATH) => self.refresh_variables(full_path),
+            Some(&REFRESH_FNS_PATH) => self.refresh_uninterpreted_fns(full_path),
+            Some(&REFRESH_REGULATIONS_PATH) => self.refresh_regulations(full_path),
+            Some(&REFRESH_LAYOUTS_PATH) => self.refresh_layouts(full_path),
+            Some(&REFRESH_LAYOUT_NODES_PATH) => self.refresh_layout_nodes(full_path, &at_path[1..]),
             _ => Self::invalid_path_error_generic(at_path),
         }
     }

--- a/src-tauri/src/sketchbook/model/_regulation.rs
+++ b/src-tauri/src/sketchbook/model/_regulation.rs
@@ -35,7 +35,7 @@ lazy_static! {
 ///  - if the regulation is `positive`, it might only *increase* the `target` value
 ///  - if the regulation is `negative`, it might only *decrease* the `target` value
 ///  - if the regulation is `dual`, it might both *increase* or *decrease* the `target` value (in
-///  different contexts)
+///    different contexts)
 ///
 /// If essentiality is set to *true*, the `regulator` *must* have influence on the outcome
 /// of the `target` update function in *some* context. If set to `False`, this regulation must have

--- a/src-tauri/src/sketchbook/model/_variable.rs
+++ b/src-tauri/src/sketchbook/model/_variable.rs
@@ -4,12 +4,11 @@ use std::fmt::{Display, Error, Formatter};
 
 /// A type safe object for a Boolean variable of a `ModelState`.
 ///
-/// Currently, it only stores the variable's `name`.
+/// Currently, it only stores the variable's `name` and `annotation`.
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct Variable {
     name: String,
     annotation: String,
-    // TODO: add compartments in future
 }
 
 impl Variable {

--- a/src-tauri/src/sketchbook/observations/_dataset/_impl_events.rs
+++ b/src-tauri/src/sketchbook/observations/_dataset/_impl_events.rs
@@ -39,7 +39,7 @@ impl Dataset {
         // prepare the state-change variant (remove IDs from the path)
         let state_change = mk_obs_state_change(&["push_obs"], &observation_data);
         // prepare the reverse event (which is a pop event)
-        let reverse_at_path = [&dataset_id.as_str(), "pop_obs"];
+        let reverse_at_path = [dataset_id.as_str(), "pop_obs"];
         let reverse_event = mk_obs_event(&reverse_at_path, None);
         Ok(make_reversible(state_change, event, reverse_event))
     }
@@ -62,7 +62,7 @@ impl Dataset {
         // prepare the state-change variant - classical push_obs event
         let state_change = mk_obs_state_change(&["push_obs"], &observation_data);
         // prepare the reverse event (which is a pop event)
-        let reverse_at_path = [&dataset_id.as_str(), "pop_obs"];
+        let reverse_at_path = [dataset_id.as_str(), "pop_obs"];
         let reverse_event = mk_obs_event(&reverse_at_path, None);
         Ok(make_reversible(state_change, event, reverse_event))
     }

--- a/src-tauri/src/sketchbook/observations/_manager/_impl_session_state.rs
+++ b/src-tauri/src/sketchbook/observations/_manager/_impl_session_state.rs
@@ -11,6 +11,41 @@ use crate::sketchbook::ids::{DatasetId, ObservationId};
 use crate::sketchbook::observations::{Dataset, ObservationManager};
 use crate::sketchbook::JsonSerde;
 
+/* Constants for event path segments in `ObservationManager` for datasets and observations. */
+
+// add a new prepared dataset
+const ADD_DATASET_PATH: &str = "add";
+// add a new default dataset
+const ADD_DEFAULT_DATASET_PATH: &str = "add_default";
+// load dataset from a specific file
+const LOAD_DATASET_PATH: &str = "load";
+// remove particular dataset
+const REMOVE_DATASET_PATH: &str = "remove";
+// set ID of a particular dataset
+const SET_DATASET_ID_PATH: &str = "set_id";
+// set whole content of a particular dataset
+const SET_DATASET_CONTENT_PATH: &str = "set_content";
+// set metadata of a particular dataset (name, variables) - does not set observations
+const SET_DATASET_METADATA_PATH: &str = "set_metadata";
+// remove a particular variable from dataset
+const REMOVE_VARIABLE_PATH: &str = "remove_var";
+// add variable to a dataset
+const ADD_VARIABLE_PATH: &str = "add_var";
+// set ID of a particular variable in a dataset
+const SET_VARIABLE_ID_PATH: &str = "set_var_id";
+// push observation to a dataset
+const PUSH_OBS_PATH: &str = "push_obs";
+// push empty observation to a dataset
+const PUSH_EMPTY_OBS_PATH: &str = "push_empty_obs";
+// pop observation from a dataset
+const POP_OBS_PATH: &str = "pop_obs";
+// refresh all datasets
+const GET_ALL_DATASETS_PATH: &str = "get_all_datasets";
+// refresh particular dataset
+const GET_DATASET_PATH: &str = "get_dataset";
+// refresh a given observation of a particular dataset
+const GET_OBSERVATION_PATH: &str = "get_observation";
+
 impl SessionHelper for ObservationManager {}
 
 impl SessionState for ObservationManager {
@@ -21,13 +56,13 @@ impl SessionState for ObservationManager {
         // when adding new dataset, the `at_path` is just ["add"] or ["add_default"]
         // when editing existing dataset, the `at_path` is ["dataset_id", ...]
 
-        if Self::starts_with("add_default", at_path).is_some() {
+        if Self::starts_with(ADD_DEFAULT_DATASET_PATH, at_path).is_some() {
             Self::assert_path_length(at_path, 1, component_name)?;
             self.event_add_default_dataset(event)
-        } else if Self::starts_with("add", at_path).is_some() {
+        } else if Self::starts_with(ADD_DATASET_PATH, at_path).is_some() {
             Self::assert_path_length(at_path, 1, component_name)?;
             self.event_add_dataset(event)
-        } else if Self::starts_with("load", at_path).is_some() {
+        } else if Self::starts_with(LOAD_DATASET_PATH, at_path).is_some() {
             Self::assert_path_length(at_path, 1, component_name)?;
             self.event_load_dataset(event)
         } else {
@@ -42,7 +77,7 @@ impl SessionState for ObservationManager {
 
         // currently three options: get all datasets, a single dataset, a single observation
         match at_path.first() {
-            Some(&"get_all_datasets") => {
+            Some(&GET_ALL_DATASETS_PATH) => {
                 Self::assert_path_length(at_path, 1, component_name)?;
                 let mut dataset_list: Vec<DatasetData> = self
                     .datasets
@@ -53,7 +88,7 @@ impl SessionState for ObservationManager {
                 dataset_list.sort_by(|a, b| a.id.cmp(&b.id));
                 make_refresh_event(full_path, dataset_list)
             }
-            Some(&"get_dataset") => {
+            Some(&GET_DATASET_PATH) => {
                 // path specifies dataset's ID
                 Self::assert_path_length(at_path, 2, component_name)?;
                 let dataset_id_str = at_path[1];
@@ -68,7 +103,7 @@ impl SessionState for ObservationManager {
 
                 Ok(Event { path, payload })
             }
-            Some(&"get_observation") => {
+            Some(&GET_OBSERVATION_PATH) => {
                 // path specifies 1) dataset's ID and 2) observation's ID
                 Self::assert_path_length(at_path, 3, component_name)?;
                 let dataset_id_str = at_path[1];
@@ -163,169 +198,181 @@ impl ObservationManager {
         //     2) modify a specific observation with `at_path` being ["observation_id", ...]
         // the second option is handled by the dataset instance itself
 
-        if Self::starts_with("remove", at_path).is_some() {
-            Self::assert_payload_empty(event, component_name)?;
+        match at_path.first() {
+            Some(&REMOVE_DATASET_PATH) => {
+                Self::assert_payload_empty(event, component_name)?;
 
-            // save the original dataset data for state change and reverse event
-            let original_dataset = self.get_dataset(&dataset_id)?.clone();
-            let dataset_data = DatasetData::from_dataset(&dataset_id, &original_dataset);
+                // save the original dataset data for state change and reverse event
+                let original_dataset = self.get_dataset(&dataset_id)?.clone();
+                let dataset_data = DatasetData::from_dataset(&dataset_id, &original_dataset);
 
-            // perform the event, prepare the state-change variant (move IDs from path to payload)
-            self.remove_dataset(&dataset_id)?;
-            let state_change = mk_obs_state_change(&["remove"], &dataset_data);
+                // perform the event, prepare the state-change variant (move IDs from path to payload)
+                self.remove_dataset(&dataset_id)?;
+                let state_change = mk_obs_state_change(&["remove"], &dataset_data);
 
-            // prepare the reverse 'add' event (path has no ids, all info carried by payload)
-            let payload = dataset_data.to_json_str();
-            let reverse_event = mk_obs_event(&["add"], Some(&payload));
-            Ok(make_reversible(state_change, event, reverse_event))
-        } else if Self::starts_with("set_id", at_path).is_some() {
-            // get the payload - string for "new_id"
-            let new_id = Self::clone_payload_str(event, component_name)?;
-            if dataset_id.as_str() == new_id.as_str() {
-                return Ok(Consumed::NoChange);
+                // prepare the reverse 'add' event (path has no ids, all info carried by payload)
+                let payload = dataset_data.to_json_str();
+                let reverse_event = mk_obs_event(&["add"], Some(&payload));
+                Ok(make_reversible(state_change, event, reverse_event))
             }
+            Some(&SET_DATASET_ID_PATH) => {
+                // get the payload - string for "new_id"
+                let new_id = Self::clone_payload_str(event, component_name)?;
+                if dataset_id.as_str() == new_id.as_str() {
+                    return Ok(Consumed::NoChange);
+                }
 
-            // perform the event, prepare the state-change variant (move id from path to payload)
-            self.set_dataset_id_by_str(dataset_id.as_str(), new_id.as_str())?;
-            let id_change_data = ChangeIdData::new(dataset_id.as_str(), new_id.as_str());
-            let state_change = mk_obs_state_change(&["set_id"], &id_change_data);
+                // perform the event, prepare the state-change variant (move id from path to payload)
+                self.set_dataset_id_by_str(dataset_id.as_str(), new_id.as_str())?;
+                let id_change_data = ChangeIdData::new(dataset_id.as_str(), new_id.as_str());
+                let state_change = mk_obs_state_change(&["set_id"], &id_change_data);
 
-            // prepare the reverse event (setting the original ID back)
-            let payload = dataset_id.as_str();
-            let reverse_event = mk_obs_event(&[new_id.as_str(), "set_id"], Some(payload));
-            Ok(make_reversible(state_change, event, reverse_event))
-        } else if Self::starts_with("set_content", at_path).is_some() {
-            // get the payload - json string encoding a new dataset data
-            let payload = Self::clone_payload_str(event, component_name)?;
-            let new_dataset_data = DatasetData::from_json_str(&payload)?;
-            let new_dataset = new_dataset_data.to_dataset()?;
-            let orig_dataset = self.get_dataset(&dataset_id)?;
-            if orig_dataset == &new_dataset {
-                return Ok(Consumed::NoChange);
+                // prepare the reverse event (setting the original ID back)
+                let payload = dataset_id.as_str();
+                let reverse_event = mk_obs_event(&[new_id.as_str(), "set_id"], Some(payload));
+                Ok(make_reversible(state_change, event, reverse_event))
             }
+            Some(&SET_DATASET_CONTENT_PATH) => {
+                // get the payload - json string encoding a new dataset data
+                let payload = Self::clone_payload_str(event, component_name)?;
+                let new_dataset_data = DatasetData::from_json_str(&payload)?;
+                let new_dataset = new_dataset_data.to_dataset()?;
+                let orig_dataset = self.get_dataset(&dataset_id)?;
+                if orig_dataset == &new_dataset {
+                    return Ok(Consumed::NoChange);
+                }
 
-            // perform the event, prepare the state-change variant (move id from path to payload)
-            let orig_dataset_data = DatasetData::from_dataset(&dataset_id, orig_dataset);
-            self.swap_dataset_content(&dataset_id, new_dataset)?;
-            let state_change = mk_obs_state_change(&["set_content"], &new_dataset_data);
+                // perform the event, prepare the state-change variant (move id from path to payload)
+                let orig_dataset_data = DatasetData::from_dataset(&dataset_id, orig_dataset);
+                self.swap_dataset_content(&dataset_id, new_dataset)?;
+                let state_change = mk_obs_state_change(&["set_content"], &new_dataset_data);
 
-            // prepare the reverse event (setting the original ID back)
-            let reverse_at_path = [dataset_id.as_str(), "set_content"];
-            let payload = orig_dataset_data.to_json_str();
-            let reverse_event = mk_obs_event(&reverse_at_path, Some(&payload));
-            Ok(make_reversible(state_change, event, reverse_event))
-        } else if Self::starts_with("set_metadata", at_path).is_some() {
-            // get the payload - json string encoding metadata with (potentially) new name/annotation/variables
-            let payload = Self::clone_payload_str(event, component_name)?;
-            let new_metadata = DatasetMetaData::from_json_str(&payload)?;
-            let orig_dataset = self.get_dataset(&dataset_id)?;
-            if orig_dataset.get_name() == new_metadata.name
-                && orig_dataset.get_annotation() == new_metadata.annotation
-                && orig_dataset.variable_names() == new_metadata.variables
-            {
-                return Ok(Consumed::NoChange);
+                // prepare the reverse event (setting the original ID back)
+                let reverse_at_path = [dataset_id.as_str(), "set_content"];
+                let payload = orig_dataset_data.to_json_str();
+                let reverse_event = mk_obs_event(&reverse_at_path, Some(&payload));
+                Ok(make_reversible(state_change, event, reverse_event))
             }
+            Some(&SET_DATASET_METADATA_PATH) => {
+                // get the payload - json string encoding metadata with (potentially) new name/annotation/variables
+                let payload = Self::clone_payload_str(event, component_name)?;
+                let new_metadata = DatasetMetaData::from_json_str(&payload)?;
+                let orig_dataset = self.get_dataset(&dataset_id)?;
+                if orig_dataset.get_name() == new_metadata.name
+                    && orig_dataset.get_annotation() == new_metadata.annotation
+                    && orig_dataset.variable_names() == new_metadata.variables
+                {
+                    return Ok(Consumed::NoChange);
+                }
 
-            // perform the event, prepare the state-change variant (move id from path to payload)
-            let orig_metadata = DatasetMetaData::from_dataset(&dataset_id, orig_dataset);
-            self.set_dataset_name(&dataset_id, &new_metadata.name)?;
-            self.set_dataset_annot(&dataset_id, &new_metadata.annotation)?;
-            let variables = new_metadata.variables.iter().map(|v| v.as_str()).collect();
-            self.set_all_variables_by_str(dataset_id.as_str(), variables)?;
-            let state_change = mk_obs_state_change(&["set_metadata"], &new_metadata);
+                // perform the event, prepare the state-change variant (move id from path to payload)
+                let orig_metadata = DatasetMetaData::from_dataset(&dataset_id, orig_dataset);
+                self.set_dataset_name(&dataset_id, &new_metadata.name)?;
+                self.set_dataset_annot(&dataset_id, &new_metadata.annotation)?;
+                let variables = new_metadata.variables.iter().map(|v| v.as_str()).collect();
+                self.set_all_variables_by_str(dataset_id.as_str(), variables)?;
+                let state_change = mk_obs_state_change(&["set_metadata"], &new_metadata);
 
-            // prepare the reverse event (setting the original ID back)
-            let reverse_at_path = [dataset_id.as_str(), "set_metadata"];
-            let payload = orig_metadata.to_json_str();
-            let reverse_event = mk_obs_event(&reverse_at_path, Some(&payload));
-            Ok(make_reversible(state_change, event, reverse_event))
-        } else if Self::starts_with("remove_var", at_path).is_some() {
-            // get the payload - string encoding a new dataset data
-            let var_id_str = Self::clone_payload_str(event, component_name)?;
-
-            // perform the event, prepare the state-change variant (move id from path to payload)
-            self.remove_var_by_str(dataset_id.as_str(), var_id_str.as_str())?;
-            let new_dataset = self.get_dataset(&dataset_id)?;
-            let new_dataset_data = DatasetData::from_dataset(&dataset_id, new_dataset);
-            let state_change = mk_obs_state_change(&["remove_var"], &new_dataset_data);
-
-            // TODO: make this potentially reversible?
-            Ok(Consumed::Irreversible {
-                state_change,
-                reset: true,
-            })
-        } else if Self::starts_with("add_var", at_path).is_some() {
-            Self::assert_payload_empty(event, component_name)?;
-
-            // prepare the placeholder var and add it
-            let var_id = self.generate_var_id(&dataset_id, "var", Some(1));
-            self.add_var(&dataset_id, var_id)?;
-
-            // prepare the state-change variant (move id from path to payload)
-            let new_dataset = self.get_dataset(&dataset_id)?;
-            let new_dataset_data = DatasetData::from_dataset(&dataset_id, new_dataset);
-            let state_change = mk_obs_state_change(&["add_var"], &new_dataset_data);
-
-            // TODO: make this potentially reversible?
-            Ok(Consumed::Irreversible {
-                state_change,
-                reset: true,
-            })
-        } else if Self::starts_with("set_var_id", at_path).is_some() {
-            // get the payload - string for ChangeIdData
-            let payload = Self::clone_payload_str(event, component_name)?;
-            let id_change_data = ChangeIdData::from_json_str(&payload)?;
-            let orig_id = id_change_data.original_id;
-            let new_id = id_change_data.new_id;
-            if orig_id == new_id {
-                return Ok(Consumed::NoChange);
+                // prepare the reverse event (setting the original ID back)
+                let reverse_at_path = [dataset_id.as_str(), "set_metadata"];
+                let payload = orig_metadata.to_json_str();
+                let reverse_event = mk_obs_event(&reverse_at_path, Some(&payload));
+                Ok(make_reversible(state_change, event, reverse_event))
             }
+            Some(&REMOVE_VARIABLE_PATH) => {
+                // get the payload - string encoding variable ID
+                let var_id_str = Self::clone_payload_str(event, component_name)?;
 
-            // perform the event, prepare the state-change variant (move id from path to payload)
-            let orig_dataset = self.get_dataset(&dataset_id)?;
-            let orig_metadata = DatasetMetaData::from_dataset(&dataset_id, orig_dataset);
-            self.set_var_id_by_str(dataset_id.as_str(), &orig_id, &new_id)?;
-            let state_change = mk_obs_state_change(&["set_var_id"], &orig_metadata);
+                // perform the event, prepare the state-change variant (move id from path to payload)
+                self.remove_var_by_str(dataset_id.as_str(), var_id_str.as_str())?;
+                let new_dataset = self.get_dataset(&dataset_id)?;
+                let new_dataset_data = DatasetData::from_dataset(&dataset_id, new_dataset);
+                let state_change = mk_obs_state_change(&["remove_var"], &new_dataset_data);
 
-            // prepare the reverse event
-            let reverse_at_path = [dataset_id.as_str(), "set_var_id"];
-            let payload = ChangeIdData::new(&new_id, &orig_id).to_json_str();
-            let reverse_event = mk_obs_event(&reverse_at_path, Some(&payload));
-            Ok(make_reversible(state_change, event, reverse_event))
-        } else if Self::starts_with("push_obs", at_path).is_some() {
-            // Adding particular observation to the end of a specific dataset
-            // This is handled by the `Dataset` itself
+                // TODO: make this potentially reversible?
+                Ok(Consumed::Irreversible {
+                    state_change,
+                    reset: true,
+                })
+            }
+            Some(&ADD_VARIABLE_PATH) => {
+                Self::assert_payload_empty(event, component_name)?;
 
-            // the ID is valid (checked before), we can unwrap
-            let dataset = self.datasets.get_mut(&dataset_id).unwrap();
-            dataset.event_push_observation(event, dataset_id)
-        } else if Self::starts_with("push_empty_obs", at_path).is_some() {
-            // Adding new empty observation to the end of a specific dataset
-            // This is handled by the `Dataset` itself
+                // prepare the placeholder var and add it
+                let var_id = self.generate_var_id(&dataset_id, "var", Some(1));
+                self.add_var(&dataset_id, var_id)?;
 
-            // the ID is valid (checked before), we can unwrap
-            let dataset = self.datasets.get_mut(&dataset_id).unwrap();
-            dataset.event_push_empty_observation(event, dataset_id)
-        } else if Self::starts_with("pop_obs", at_path).is_some() {
-            // Removing last observation from the end of a specific dataset
-            // This is handled by the `Dataset` itself
+                // prepare the state-change variant (move id from path to payload)
+                let new_dataset = self.get_dataset(&dataset_id)?;
+                let new_dataset_data = DatasetData::from_dataset(&dataset_id, new_dataset);
+                let state_change = mk_obs_state_change(&["add_var"], &new_dataset_data);
 
-            // the ID is valid (checked before), we can unwrap
-            let dataset = self.datasets.get_mut(&dataset_id).unwrap();
-            dataset.event_pop_observation(event, dataset_id)
-        } else {
-            // Finally, remaining events must be some kind of modification of a specific observation
-            // The `at_path` must be ["observation_id", <ACTION>]
+                // TODO: make this potentially reversible?
+                Ok(Consumed::Irreversible {
+                    state_change,
+                    reset: true,
+                })
+            }
+            Some(&SET_VARIABLE_ID_PATH) => {
+                // get the payload - string for ChangeIdData
+                let payload = Self::clone_payload_str(event, component_name)?;
+                let id_change_data = ChangeIdData::from_json_str(&payload)?;
+                let orig_id = id_change_data.original_id;
+                let new_id = id_change_data.new_id;
+                if orig_id == new_id {
+                    return Ok(Consumed::NoChange);
+                }
 
-            // We just extract the particular ID and let the `Dataset` handle it itself
-            Self::assert_path_length(at_path, 2, component_name)?;
-            let observation_id_str = at_path[0];
-            let obs_id = ObservationId::new(observation_id_str)?;
-            let action = at_path[1];
+                // perform the event, prepare the state-change variant (move id from path to payload)
+                let orig_dataset = self.get_dataset(&dataset_id)?;
+                let orig_metadata = DatasetMetaData::from_dataset(&dataset_id, orig_dataset);
+                self.set_var_id_by_str(dataset_id.as_str(), &orig_id, &new_id)?;
+                let state_change = mk_obs_state_change(&["set_var_id"], &orig_metadata);
 
-            // the ID is valid (checked before), we can unwrap
-            let dataset = self.datasets.get_mut(&dataset_id).unwrap();
-            dataset.event_modify_observation(event, action, dataset_id, obs_id)
+                // prepare the reverse event
+                let reverse_at_path = [dataset_id.as_str(), "set_var_id"];
+                let payload = ChangeIdData::new(&new_id, &orig_id).to_json_str();
+                let reverse_event = mk_obs_event(&reverse_at_path, Some(&payload));
+                Ok(make_reversible(state_change, event, reverse_event))
+            }
+            Some(&PUSH_OBS_PATH) => {
+                // Adding particular observation to the end of a specific dataset
+                // This is handled by the `Dataset` itself
+
+                // the ID is valid (checked before), we can unwrap
+                let dataset = self.datasets.get_mut(&dataset_id).unwrap();
+                dataset.event_push_observation(event, dataset_id)
+            }
+            Some(&PUSH_EMPTY_OBS_PATH) => {
+                // Adding new empty observation to the end of a specific dataset
+                // This is handled by the `Dataset` itself
+
+                // the ID is valid (checked before), we can unwrap
+                let dataset = self.datasets.get_mut(&dataset_id).unwrap();
+                dataset.event_push_empty_observation(event, dataset_id)
+            }
+            Some(&POP_OBS_PATH) => {
+                // Removing last observation from the end of a specific dataset
+                // This is handled by the `Dataset` itself
+
+                // the ID is valid (checked before), we can unwrap
+                let dataset = self.datasets.get_mut(&dataset_id).unwrap();
+                dataset.event_pop_observation(event, dataset_id)
+            }
+            _ => {
+                // Finally, remaining events must be some kind of modification of a specific observation
+                // The `at_path` must be ["observation_id", <ACTION>]
+
+                // We just extract the particular ID and let the `Dataset` handle it itself
+                Self::assert_path_length(at_path, 2, component_name)?;
+                let observation_id_str = at_path[0];
+                let obs_id = ObservationId::new(observation_id_str)?;
+                let action = at_path[1];
+
+                // the ID is valid (checked before), we can unwrap
+                let dataset = self.datasets.get_mut(&dataset_id).unwrap();
+                dataset.event_modify_observation(event, action, dataset_id, obs_id)
+            }
         }
     }
 }

--- a/src-tauri/src/sketchbook/observations/_manager/_impl_session_state.rs
+++ b/src-tauri/src/sketchbook/observations/_manager/_impl_session_state.rs
@@ -53,7 +53,7 @@ impl SessionState for ObservationManager {
         let component_name = "observations";
 
         // there is either adding/loading of a new dataset, or modifying/removing an existing one
-        // when adding new dataset, the `at_path` is just ["add"] or ["add_default"]
+        // when adding new dataset, the `at_path` is just ["add"], ["add_default"], or ["load"]
         // when editing existing dataset, the `at_path` is ["dataset_id", ...]
 
         if Self::starts_with(ADD_DEFAULT_DATASET_PATH, at_path).is_some() {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
     "withGlobalTauri": true
   },
   "package": {
-    "productName": "AEON Sketchbook",
+    "productName": "Biodivine Sketchbook",
     "version": "0.1.0"
   },
   "tauri": {
@@ -59,7 +59,7 @@
         "label": "editor",
         "fullscreen": false,
         "resizable": true,
-        "title": "AEON Sketchbook",
+        "title": "Biodivine Sketchbook",
         "width": 1100,
         "height": 666,
         "minWidth": 1000,

--- a/src/aeon_state.ts
+++ b/src/aeon_state.ts
@@ -6,8 +6,8 @@ import {
 } from './aeon_events'
 
 import {
-  Monotonicity,
-  Essentiality,
+  type Monotonicity,
+  type Essentiality,
   type DynamicProperty,
   type StaticProperty,
   type DynamicPropertyType,
@@ -231,10 +231,6 @@ interface AeonState {
 
       /** VariableData for a newly created variable. */
       variableCreated: Observable<VariableData>
-      /** Create new variable with given ID and name.
-       * If only ID string is given, it is used for both ID and name.
-       * Variable is placed on a given position. */
-      addVariable: (varId: string, varName?: string, position?: LayoutNodeDataPrototype | LayoutNodeDataPrototype[]) => void
       /** Create new variable with automatically generated ID and name.
        * Variable is placed on a given position. */
       addDefaultVariable: (position?: LayoutNodeDataPrototype | LayoutNodeDataPrototype[]) => void
@@ -261,11 +257,8 @@ interface AeonState {
 
       /** UninterpretedFnData for a newly created uninterpreted function. */
       uninterpretedFnCreated: Observable<UninterpretedFnData>
-      /** Create new uninterpreted function with given arity, ID, and name.
-       * If name is not given, ID string is used for both ID and name. */
-      addUninterpretedFn: (uninterpretedFnId: string, arity: number, uninterpretedFnName?: string) => void
-      /** Create new uninterpreted function with automatically generated ID and name, and with zero arity & no
-       * additional constraints. */
+      /** Create new uninterpreted function with automatically generated ID and name, and with
+       * zero arity & no additional constraints. */
       addDefaultUninterpretedFn: () => void
       /** UninterpretedFnData of a removed uninterpreted function. */
       uninterpretedFnRemoved: Observable<UninterpretedFnData>
@@ -362,8 +355,6 @@ interface AeonState {
 
       /** DatasetData for a newly created dataset. */
       datasetCreated: Observable<DatasetData>
-      /** Create a new dataset with given ID, variables, and observations. */
-      addDataset: (id: string, variables: string[], observations: ObservationData[]) => void
       /** Create a new empty dataset. */
       addDefaultDataset: () => void
       /** DatasetData for a newly loaded dataset (from a csv file).
@@ -440,8 +431,6 @@ interface AeonState {
 
       /** Newly created dynamic property. */
       dynamicCreated: Observable<DynamicProperty>
-      /** Create a new dynamic property with given ID, variables, of given `variant` (with corresponding data). */
-      addDynamic: (id: string, name: string, variant: DynamicProperty) => void
       /** Create a new default dynamic property of given variant. */
       addDefaultDynamic: (variant: DynamicPropertyType) => void
       /** Data of a removed dynamic property. */
@@ -461,8 +450,6 @@ interface AeonState {
 
       /** Newly created static property. */
       staticCreated: Observable<StaticProperty>
-      /** Create a new static property with given ID, variables, of given `variant` (with corresponding data). */
-      addStatic: (id: string, name: string, variant: StaticProperty) => void
       /** Create a new default static property with given ID and variant. */
       addDefaultStatic: (variant: StaticPropertyType) => void
       /** Data of a removed static property. */
@@ -697,25 +684,6 @@ export const aeonState: AeonState = {
       layoutRemoved: new Observable<LayoutData>(['sketch', 'model', 'layout', 'remove']),
       nodePositionChanged: new Observable<LayoutNodeData>(['sketch', 'model', 'layout', 'update_position']),
 
-      addVariable (
-        varId: string = '',
-        varName: string = '',
-        position: LayoutNodeDataPrototype | LayoutNodeDataPrototype[] = []
-      ): void {
-        if (varName === undefined) {
-          varName = varId
-        }
-
-        if (!Array.isArray(position)) {
-          position = [position]
-        }
-
-        // First action creates the variable, either default or given.
-        aeonEvents.emitAction({
-          path: ['sketch', 'model', 'variable', 'add'],
-          payload: JSON.stringify({ variable: { id: varId, name: varName, update_fn: '' }, layouts: position })
-        })
-      },
       addDefaultVariable (position: LayoutNodeDataPrototype | LayoutNodeDataPrototype[] = []): void {
         if (!Array.isArray(position)) {
           position = [position]
@@ -749,20 +717,6 @@ export const aeonState: AeonState = {
         aeonEvents.emitAction({
           path: ['sketch', 'model', 'variable', varId, 'set_update_fn'],
           payload: newExpression
-        })
-      },
-      addUninterpretedFn (uninterpretedFnId: string, arity: number, uninterpretedFnName: string = ''): void {
-        if (uninterpretedFnName === '') {
-          uninterpretedFnName = uninterpretedFnId
-        }
-        aeonEvents.emitAction({
-          path: ['sketch', 'model', 'uninterpreted_fn', 'add'],
-          payload: JSON.stringify({
-            id: uninterpretedFnId,
-            name: uninterpretedFnName,
-            arguments: Array(arity).fill([Monotonicity.UNSPECIFIED, Essentiality.UNKNOWN]),
-            expression: ''
-          })
         })
       },
       addDefaultUninterpretedFn (): void {
@@ -903,16 +857,6 @@ export const aeonState: AeonState = {
       observationIdChanged: new Observable<ObservationIdUpdateData>(['sketch', 'observations', 'set_obs_id']),
       observationDataChanged: new Observable<ObservationData>(['sketch', 'observations', 'set_obs_data']),
 
-      addDataset (id: string, variables: string[], observations: ObservationData[]): void {
-        aeonEvents.emitAction({
-          path: ['sketch', 'observations', 'add'],
-          payload: JSON.stringify({
-            id,
-            variables,
-            observations
-          })
-        })
-      },
       addDefaultDataset (): void {
         aeonEvents.emitAction({
           path: ['sketch', 'observations', 'add_default'],
@@ -1024,16 +968,6 @@ export const aeonState: AeonState = {
       staticRemoved: new Observable<StaticProperty>(['sketch', 'properties', 'static', 'remove']),
       staticIdChanged: new Observable<StatPropIdUpdateData>(['sketch', 'properties', 'static', 'set_id']),
 
-      addDynamic (id: string, name: string, variant: DynamicProperty): void {
-        aeonEvents.emitAction({
-          path: ['sketch', 'properties', 'dynamic', 'add'],
-          payload: JSON.stringify({
-            id,
-            name,
-            variant
-          })
-        })
-      },
       addDefaultDynamic (variant: DynamicPropertyType): void {
         aeonEvents.emitAction({
           path: ['sketch', 'properties', 'dynamic', 'add_default'],
@@ -1056,16 +990,6 @@ export const aeonState: AeonState = {
         aeonEvents.emitAction({
           path: ['sketch', 'properties', 'dynamic', originalId, 'set_id'],
           payload: newId
-        })
-      },
-      addStatic (id: string, name: string, variant: StaticProperty): void {
-        aeonEvents.emitAction({
-          path: ['sketch', 'properties', 'static', 'add'],
-          payload: JSON.stringify({
-            id,
-            name,
-            variant
-          })
         })
       },
       addDefaultStatic (variant: StaticPropertyType): void {

--- a/src/html/component-editor/properties-editor/properties-editor.ts
+++ b/src/html/component-editor/properties-editor/properties-editor.ts
@@ -43,10 +43,10 @@ export default class PropertiesEditor extends LitElement {
 
   addDynamicPropertyMenu: IAddPropertyItem[] = [
     {
-      label: 'Trap space',
+      label: 'Exists trap space',
       action: () => { this.addDynamicProperty(DynamicPropertyType.TrapSpace) }
     }, {
-      label: 'Fixed point',
+      label: 'Exists fixed point',
       action: () => { this.addDynamicProperty(DynamicPropertyType.FixedPoint) }
     }, {
       label: 'Exists trajectory',
@@ -55,7 +55,7 @@ export default class PropertiesEditor extends LitElement {
       label: 'Attractor count',
       action: () => { this.addDynamicProperty(DynamicPropertyType.AttractorCount) }
     }, {
-      label: 'Has attractor',
+      label: 'Exists attractor',
       action: () => { this.addDynamicProperty(DynamicPropertyType.HasAttractor) }
     }, {
       label: 'Generic',
@@ -65,16 +65,16 @@ export default class PropertiesEditor extends LitElement {
 
   addStaticPropertyMenu: IAddPropertyItem[] = [
     {
-      label: 'Essential function input',
+      label: 'Function input essential',
       action: () => { this.addStaticProperty(StaticPropertyType.FunctionInputEssentialWithCondition) }
     }, {
-      label: 'Essential variable regulation',
+      label: 'Regulation essential',
       action: () => { this.addStaticProperty(StaticPropertyType.VariableRegulationEssentialWithCondition) }
     }, {
-      label: 'Monotonic function input',
+      label: 'Function input monotonic',
       action: () => { this.addStaticProperty(StaticPropertyType.FunctionInputMonotonicWithCondition) }
     }, {
-      label: 'Monotonic variable regulation',
+      label: 'Regulation monotonic',
       action: () => { this.addStaticProperty(StaticPropertyType.VariableRegulationMonotonicWithCondition) }
     }, {
       label: 'Generic',

--- a/src/html/component-editor/regulations-editor/regulations-editor.less
+++ b/src/html/component-editor/regulations-editor/regulations-editor.less
@@ -18,7 +18,7 @@
 }
 
 #quick-help {
-  position: fixed;
+  position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -40%);
@@ -26,5 +26,13 @@
   border-radius: 12px;
   font-size: 18px;
   opacity: 0.95;
-  transition: 0.3s;
+  transition: 0.2s;
+  z-index: 5;
+}
+
+.help-button {
+  position: absolute;
+  z-index: 5;
+  right: 0;
+  bottom: 0;
 }

--- a/src/html/component-editor/regulations-editor/regulations-editor.ts
+++ b/src/html/component-editor/regulations-editor/regulations-editor.ts
@@ -22,6 +22,7 @@ export class RegulationsEditor extends LitElement {
   lastTabCount = 1
   highlighted = ''
   @property() contentData = ContentData.create()
+  @state() showHelp = false
   @state() menuType = ElementType.NONE
   @state() menuPosition = { x: 0, y: 0 }
   @state() menuZoom = 1.0
@@ -398,7 +399,7 @@ export class RegulationsEditor extends LitElement {
       <div class="header uk-background-primary">
         <h3 class="uk-heading-bullet uk-margin-remove-bottom ">Network</h3>
       </div>
-      ${this.contentData.variables.length === 0
+      ${this.contentData.variables.length === 0 || this.showHelp
 ? html`
         <div id="quick-help" class="help-message-block">
           <h3 style="display: block; margin: 0 auto; float: right;">HELP</h3>
@@ -427,6 +428,9 @@ export class RegulationsEditor extends LitElement {
         <float-menu .type=${this.menuType} .position=${this.menuPosition} .zoom=${this.menuZoom}
                     .data=${this.menuData}></float-menu>
       </div>
+      <button class="uk-button uk-button-small uk-button-secondary help-button" @mouseenter="${() => { this.showHelp = true }}" @mouseleave="${() => { this.showHelp = false }}">
+        ?
+      </button>
     `
   }
 }

--- a/src/html/util/config.ts
+++ b/src/html/util/config.ts
@@ -2,7 +2,7 @@ import { TabData } from './tab-data'
 import { html } from 'lit'
 
 export const functionDebounceTimer = 1500
-export const inferencePingTimer = 250
+export const inferencePingTimer = 200
 
 let index = 0
 

--- a/src/html/util/config.ts
+++ b/src/html/util/config.ts
@@ -40,7 +40,7 @@ export const tabList: TabData[] = [
   }),
   TabData.create({
     id: index++,
-    name: 'Inference',
+    name: 'Analysis',
     content: (contentData) => html`<analysis-tab .contentData=${contentData}></analysis-tab>`,
     icon: 'i'
   })

--- a/src/tests/utilities.test.ts
+++ b/src/tests/utilities.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from 'vitest'
+import {
+  getNextEssentiality,
+  getEssentialityText,
+  getNextMonotonicity,
+  getMonotonicityClass
+} from '../html/util/utilities'
+import { Essentiality, Monotonicity } from '../html/util/data-interfaces'
+
+test('getNextEssentiality', () => {
+  expect(getNextEssentiality(Essentiality.FALSE)).toEqual(Essentiality.TRUE)
+  expect(getNextEssentiality(Essentiality.TRUE)).toEqual(Essentiality.UNKNOWN)
+  expect(getNextEssentiality(Essentiality.UNKNOWN)).toEqual(Essentiality.FALSE)
+})
+
+test('getEssentialityText', () => {
+  expect(getEssentialityText(Essentiality.FALSE)).toEqual('non-essential')
+  expect(getEssentialityText(Essentiality.TRUE)).toEqual('essential')
+  expect(getEssentialityText(Essentiality.UNKNOWN)).toEqual('unknown')
+})
+
+test('getNextMonotonicity', () => {
+  expect(getNextMonotonicity(Monotonicity.ACTIVATION)).toEqual(Monotonicity.INHIBITION)
+  expect(getNextMonotonicity(Monotonicity.INHIBITION)).toEqual(Monotonicity.DUAL)
+  expect(getNextMonotonicity(Monotonicity.DUAL)).toEqual(Monotonicity.UNSPECIFIED)
+  expect(getNextMonotonicity(Monotonicity.UNSPECIFIED)).toEqual(Monotonicity.ACTIVATION)
+})
+
+test('getMonotonicityClass', () => {
+  expect(getMonotonicityClass(Monotonicity.ACTIVATION)).toEqual('monotonicity-activation')
+  expect(getMonotonicityClass(Monotonicity.INHIBITION)).toEqual('monotonicity-inhibition')
+  expect(getMonotonicityClass(Monotonicity.DUAL)).toEqual('monotonicity-dual')
+  expect(getMonotonicityClass(Monotonicity.UNSPECIFIED)).toEqual('monotonicity-unspecified')
+})

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,82 @@
+import os from 'os';
+import path from 'path';
+import { spawn, spawnSync } from 'child_process';
+import { Builder, By, Capabilities } from 'selenium-webdriver';
+import { expect } from 'chai';
+import { fileURLToPath } from 'url';
+
+// Create __dirname equivalent in ES modules
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Create the path to the expected application binary
+const application = path.resolve(
+  __dirname,
+  '..',
+  'src-tauri',
+  'target',
+  'release',
+  'Biodivine Sketchbook.exe'
+);
+
+// Keep track of the WebDriver instance
+let driver;
+
+// Keep track of the Tauri driver process
+let tauriDriver;
+
+before(async function () {
+  // Set timeout to 5 minutes to allow the program to build if needed
+  this.timeout(300000);
+
+  // Ensure the program has been built -- just build it beforehand for now
+  //spawnSync('cargo', ['tauri', 'build']);
+
+  // Start Tauri driver
+  tauriDriver = spawn(
+    path.resolve(os.homedir(), '.cargo', 'bin', 'tauri-driver'),
+    [],
+    { stdio: [null, process.stdout, process.stderr] }
+  );
+
+  const capabilities = new Capabilities();
+  capabilities.set('tauri:options', {
+    application: application,
+    webviewOptions: {},
+  });
+  capabilities.setBrowserName('wry')
+
+  // Start the WebDriver client
+  driver = await new Builder()
+    .withCapabilities(capabilities)
+    .usingServer('http://localhost:4444/')
+    .build();
+});
+
+after(async function () {
+  // Stop the WebDriver session
+  await driver.quit();
+
+  // Kill the Tauri driver process
+  if (tauriDriver) {
+    tauriDriver.kill();
+  }
+});
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe('Basic test attempt', () => {
+  it('should have welcome message', async () => {
+    // Waiting for the app to fully initialize...
+    await sleep(500);
+
+    const rootComponent = await driver.findElement(By.css("root-component"));
+    const initialScreenComponent = await driver.executeScript("return arguments[0].shadowRoot.querySelector('initial-screen');", rootComponent);
+    const heading = await driver.executeScript("return arguments[0].shadowRoot.querySelector('h2');", initialScreenComponent);
+    const headingText = await heading.getText();
+
+    expect(headingText).to.match(/Welcome to SketchBook/);
+  });
+});


### PR DESCRIPTION
This small PR deals with various little things:
- Some code refactoring relevant to events  (defining constants, removing unused code...)
- The tool's name is changed from the outdated AEON Sketchbook to Biodivine Sketchbook
- There is a new installation guide and instructions in the README.
- There is a prototype for the new `vitest`-based framework for front-end unit tests.
- There is a prototype for a new `selenium`-based framework for end-to-end tests.
- New dependencies versions.
- Added a new button to re-render a help message at the network editor.
- Some names for properties/tabs were changed.