### PR TITLE
New export features

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ We also utilize an end-to-end Selenium-based testing framework. Note that these 
 
 You can follow this [detailed tutorial](https://jonaskruckenberg.github.io/tauri-docs-wip/development/testing.html) for setup. In short, you should install `tauri-driver` (with `cargo install tauri-driver`), and then you will need either `WebKitWebDriver` on Linux or `Microsoft Edge Driver` on Windows (make sure that you have updated Microsoft Edge too, and that you have matching versions). The mocha test runner can be installed with `npm install mocha chai selenium-webdriver`. You might need to update the configuration at the top of the testing script `test/test.js`, mainly the path to your Sketchbook binary and to your webdriver.
 
-To run the tests, first build the app with `cargo tauri build` and then use `npx mocha` (you might need a longer timeout, like `npx mocha --timeout 20000`).
+To run the tests, first build the app with `cargo run tauri build` and then use `npx mocha` (you might need a longer timeout, like `npx mocha --timeout 20000`).
 The framework was tested on Windows with `Microsoft Edge WebDriver` version `134.0.3124.83`.
 However, note that we found the testing framework a bit unstable when the testing machine is overloaded with other tasks. Sometimes, the tests do not go through due to internal WebDriver issues, and we are investigating this.
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,7 @@ name = "biodivine-sketchbook"
 path = "src/main.rs"
 
 [dependencies]
+base64 = "0.22.1"
 biodivine-lib-bdd = ">=0.5.22, <1.0.0"
 biodivine-lib-param-bn = ">=0.5.13, <1.0.0"
 biodivine-hctl-model-checker = ">=0.3.2, <1.0.0"

--- a/src-tauri/src/sketchbook/observations/_manager/_impl_export_dataset.rs
+++ b/src-tauri/src/sketchbook/observations/_manager/_impl_export_dataset.rs
@@ -1,0 +1,80 @@
+use crate::sketchbook::ids::DatasetId;
+use crate::sketchbook::observations::ObservationManager;
+use std::fs::File;
+use std::io::Write;
+
+impl ObservationManager {
+    /// Convert the dataset to a CSV string.
+    ///
+    /// See [Self::parse_dataset_from_csv] for the details of the format. The first line contains
+    /// variable names as a header. Each subsequent line represents an observation (ID and values).
+    fn dataset_to_csv_string(&self, dataset_id: &DatasetId) -> Result<String, String> {
+        let dataset = self.get_dataset(dataset_id)?;
+        let mut csv_string = String::new();
+
+        // Add header line with variable names
+        csv_string.push_str("ID");
+        for var_id in dataset.variables() {
+            csv_string.push(',');
+            csv_string.push_str(var_id.as_str());
+        }
+        csv_string.push('\n');
+
+        // Add each observation as a line
+        for obs in dataset.observations() {
+            csv_string.push_str(obs.get_id().as_str());
+            for value in obs.get_values() {
+                csv_string.push(',');
+                csv_string.push_str(&value.to_string());
+            }
+            csv_string.push('\n');
+        }
+
+        Ok(csv_string)
+    }
+
+    /// Export particular dataset to a CSV file at given path.
+    ///
+    /// See [Self::parse_dataset_from_csv] for the details of the format. In short, the
+    /// header line specifies variable IDs, and each subsequent line represents individual
+    /// observations (id and values).
+    pub fn export_dataset_to_csv(
+        &self,
+        dataset_id: &DatasetId,
+        csv_path: &str,
+    ) -> Result<(), String> {
+        let csv_str = self.dataset_to_csv_string(dataset_id)?;
+
+        let mut file = File::create(csv_path).map_err(|e| e.to_string())?;
+        // write dataset in CSV to the file
+        file.write_all(csv_str.as_bytes())
+            .map_err(|e| e.to_string())?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sketchbook::observations::{Dataset, Observation};
+
+    #[test]
+    fn test_dataset_to_csv_string() {
+        // Prepare a dataset with observations
+        let obs1 = Observation::try_from_str("*11", "obs1").unwrap();
+        let obs2 = Observation::try_from_str("000", "obs2").unwrap();
+        let obs_list = vec![obs1, obs2];
+        let var_names = vec!["a", "b", "c"];
+        let dataset = Dataset::new("dataset_name", obs_list, var_names).unwrap();
+
+        // Instantiate an ObservationManager instance
+        let mut manager = ObservationManager::new_empty();
+        let dataset_id = DatasetId::new("d").unwrap();
+        manager.add_dataset(dataset_id.clone(), dataset).unwrap();
+
+        // Convert dataset to CSV string and compare with expected output
+        let csv_string = manager.dataset_to_csv_string(&dataset_id).unwrap();
+        let expected_csv = "ID,a,b,c\nobs1,*,1,1\nobs2,0,0,0\n";
+        assert_eq!(csv_string, expected_csv);
+    }
+}

--- a/src-tauri/src/sketchbook/observations/_manager/_impl_load_dataset.rs
+++ b/src-tauri/src/sketchbook/observations/_manager/_impl_load_dataset.rs
@@ -1,27 +1,25 @@
 use crate::sketchbook::observations::{Dataset, Observation, ObservationManager, VarValue};
-use std::fs::File;
 use std::str::FromStr;
 
 impl ObservationManager {
-    /// Load a dataset from given CSV file. The header line specifies variables, following lines
+    /// Parse a dataset from a CSV string. The header line specifies variables, following lines
     /// represent individual observations (id and values).
     ///
-    /// The resulting dataset has empty annotation string (same for all its observations).
+    /// The resulting dataset has an empty annotation string (same for all its observations).
     ///
-    /// For example, the following might be a valid CSV file for a dataset with 2 observations:
+    /// For example, the following might be a valid CSV string for a dataset with 2 observations:
     ///    ID,YOX1,CLN3,YHP1,ACE2,SWI5,MBF
     ///    Observation1,0,1,0,1,0,1
     ///    Observation2,1,0,*,1,0,*
     ///
-    pub fn load_dataset(name: &str, csv_path: &str) -> Result<Dataset, String> {
-        let csv_file = File::open(csv_path).map_err(|e| e.to_string())?;
-        let mut rdr = csv::Reader::from_reader(csv_file);
+    pub fn parse_dataset_from_csv(name: &str, csv_content: &str) -> Result<Dataset, String> {
+        let mut rdr = csv::Reader::from_reader(csv_content.as_bytes());
 
         // parse variable names from the header
         let header = rdr.headers().map_err(|e| e.to_string())?.clone();
         let variables = header.into_iter().skip(1).collect::<Vec<&str>>().clone();
 
-        // parse all raws as observations
+        // parse all rows as observations
         let mut observations = Vec::new();
         for result in rdr.records() {
             let record = result.map_err(|e| e.to_string())?;
@@ -40,13 +38,43 @@ impl ObservationManager {
         Dataset::new(name, observations, variables)
     }
 
-    /// Load a dataset from given CSV file, and add it to this `ObservationManager`. The header
-    /// line specifies variables, following lines represent individual observations (id and values).
+    /// Load a dataset from a given CSV file. Reads the file into a string and then parses it
+    /// into a dataset using [Self::parse_dataset_from_csv].
+    pub fn load_dataset(name: &str, csv_path: &str) -> Result<Dataset, String> {
+        let csv_content = std::fs::read_to_string(csv_path).map_err(|e| e.to_string())?;
+        Self::parse_dataset_from_csv(name, &csv_content)
+    }
+
+    /// Load a dataset from given CSV file, and add it to this `ObservationManager`.
     ///
-    /// See [Self::load_dataset] for details.
+    /// The header line specifies variables, following lines represent individual observations
+    /// (id and values). See [Self::parse_dataset_from_csv] for details on the format.
     pub fn load_and_add_dataset(&mut self, csv_path: &str, id: &str) -> Result<(), String> {
         // use same name as ID
         let dataset = Self::load_dataset(id, csv_path)?;
         self.add_dataset_by_str(id, dataset)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sketchbook::observations::{Dataset, Observation};
+
+    #[test]
+    fn test_dataset_to_csv_string() {
+        // Prepare expected dataset
+        let obs1 = Observation::try_from_str("*11", "obs1").unwrap();
+        let obs2 = Observation::try_from_str("000", "obs2").unwrap();
+        let obs_list = vec![obs1, obs2];
+        let var_names = vec!["a", "b", "c"];
+        let dataset_name = "dataset_name";
+        let expected_dataset = Dataset::new(dataset_name, obs_list, var_names).unwrap();
+
+        // Parse the dataset from CSV string and compare the two
+        let csv_string = "ID,a,b,c\nobs1,*,1,1\nobs2,0,0,0\n";
+        let parsed_dataset =
+            ObservationManager::parse_dataset_from_csv(dataset_name, csv_string).unwrap();
+        assert_eq!(parsed_dataset, expected_dataset);
     }
 }

--- a/src-tauri/src/sketchbook/observations/_manager/_impl_session_state.rs
+++ b/src-tauri/src/sketchbook/observations/_manager/_impl_session_state.rs
@@ -21,6 +21,8 @@ const ADD_DEFAULT_DATASET_PATH: &str = "add_default";
 const LOAD_DATASET_PATH: &str = "load";
 // remove particular dataset
 const REMOVE_DATASET_PATH: &str = "remove";
+// add a new prepared dataset
+const EXPORT_PATH: &str = "export";
 // set ID of a particular dataset
 const SET_DATASET_ID_PATH: &str = "set_id";
 // set whole content of a particular dataset
@@ -185,6 +187,8 @@ impl ObservationManager {
 
     /// Perform event of modifying or removing existing `dataset` component of this
     /// `ObservationManager`.
+    ///
+    /// Dataset export event is performed here as well.
     pub(super) fn event_modify_dataset(
         &mut self,
         event: &Event,
@@ -214,6 +218,11 @@ impl ObservationManager {
                 let payload = dataset_data.to_json_str();
                 let reverse_event = mk_obs_event(&["add"], Some(&payload));
                 Ok(make_reversible(state_change, event, reverse_event))
+            }
+            Some(&EXPORT_PATH) => {
+                let path = Self::clone_payload_str(event, component_name)?;
+                self.export_dataset_to_csv(&dataset_id, &path)?;
+                Ok(Consumed::NoChange)
             }
             Some(&SET_DATASET_ID_PATH) => {
                 // get the payload - string for "new_id"

--- a/src-tauri/src/sketchbook/observations/_manager/mod.rs
+++ b/src-tauri/src/sketchbook/observations/_manager/mod.rs
@@ -3,9 +3,11 @@ use crate::sketchbook::observations::Dataset;
 use crate::sketchbook::Manager;
 use std::collections::HashMap;
 
+/// **(internal)** Functionality for exporting datasets to files.
+mod _impl_export_dataset;
 /// **(internal)** Implementation of the safe identifier generating.
 mod _impl_id_generating;
-/// **(internal)** Functionality for loading datasets from file.
+/// **(internal)** Functionality for loading datasets from files.
 mod _impl_load_dataset;
 /// **(internal)** Basic utility methods for `ObservationManager`.
 mod _impl_manager;

--- a/src/aeon_state.ts
+++ b/src/aeon_state.ts
@@ -390,6 +390,8 @@ interface AeonState {
       datasetVariableAdded: Observable<DatasetData>
       /** Add (placeholder) variable to a specified dataset (adding an empty column to a dataset's table). */
       addDatasetVariable: (datasetId: string) => void
+      /** Export dataset with given ID to a given file. */
+      exportDataset: (id: string, path: string) => void
 
       /** ObservationData for a newly pushed observation (also contains corresponding dataset ID). */
       observationPushed: Observable<ObservationData>
@@ -912,6 +914,12 @@ export const aeonState: AeonState = {
         aeonEvents.emitAction({
           path: ['sketch', 'observations', datasetId, 'add_var'],
           payload: null
+        })
+      },
+      exportDataset (id: string, path: string): void {
+        aeonEvents.emitAction({
+          path: ['sketch', 'observations', id, 'export'],
+          payload: path
         })
       },
       pushObservation (datasetId: string, observation?: ObservationData): void {

--- a/src/aeon_state.ts
+++ b/src/aeon_state.ts
@@ -179,6 +179,8 @@ interface AeonState {
     exportSketch: (path: string) => void
     /** Export the sketch data to a file in the extended AEON format. */
     exportAeon: (path: string) => void
+    /** Export the network PNG to a file. */
+    exportNetworkPng: (path: string, pngBase64: string) => void
     /** Import the sketch data from a special sketch JSON file. */
     importSketch: (path: string) => void
     /** Import the sketch data from a AEON file. */
@@ -598,6 +600,12 @@ export const aeonState: AeonState = {
       aeonEvents.emitAction({
         path: ['sketch', 'export_aeon'],
         payload: path
+      })
+    },
+    exportNetworkPng (path: string, pngBase64: string): void {
+      aeonEvents.emitAction({
+        path: ['sketch', 'export_png'],
+        payload: JSON.stringify({ path, png: pngBase64 })
       })
     },
     importSketch (path: string): void {

--- a/src/html/component-editor/menu/menu.ts
+++ b/src/html/component-editor/menu/menu.ts
@@ -44,6 +44,10 @@ export default class Menu extends LitElement {
       action: () => { void this.exportAeon() }
     },
     {
+      label: 'Export network PNG',
+      action: () => { void this.exportNetworkPng() }
+    },
+    {
       label: 'Quit',
       action: () => { void this.quit() }
     }
@@ -130,6 +134,25 @@ export default class Menu extends LitElement {
 
     console.log('exporting aeon to', filePath)
     aeonState.sketch.exportAeon(filePath)
+  }
+
+  async exportNetworkPng (): Promise<void> {
+    const filePath = await save({
+      title: 'Export network into PNG...',
+      filters: [{
+        name: '*.png',
+        extensions: ['png']
+      }],
+      defaultPath: 'image_name_here'
+    })
+    if (filePath === null) return
+
+    // this sends an event processed in RegulationsEditor component
+    this.dispatchEvent(new CustomEvent('export-png', {
+      bubbles: true,
+      composed: true,
+      detail: { path: filePath }
+    }))
   }
 
   async newSketch (): Promise<void> {

--- a/src/html/component-editor/observations-editor/observations-editor.ts
+++ b/src/html/component-editor/observations-editor/observations-editor.ts
@@ -4,6 +4,7 @@ import style_less from './observations-editor.less?inline'
 import './observations-set/observations-set'
 import { ContentData, type IObservation, type IObservationSet } from '../../util/data-interfaces'
 import { map } from 'lit/directives/map.js'
+import { save } from '@tauri-apps/api/dialog'
 import { dialog } from '@tauri-apps/api'
 import { appWindow, WebviewWindow } from '@tauri-apps/api/window'
 import { type Event as TauriEvent } from '@tauri-apps/api/helpers/event'
@@ -40,6 +41,7 @@ export default class ObservationsEditor extends LitElement {
     this.addEventListener('remove-dataset', (e) => { void this.removeDataset(e) })
     this.addEventListener('add-dataset-variable', this.addVariable)
     this.addEventListener('edit-dataset', (e) => { void this.editDataset(e) })
+    this.addEventListener('export-dataset', (e) => { void this.exportDataset(e) })
 
     // changes to observations triggered by table edits
     this.addEventListener('change-observation', this.changeObservation)
@@ -414,6 +416,23 @@ export default class ObservationsEditor extends LitElement {
     const shownDatasets = [...this.shownDatasets]
     shownDatasets.splice(dsIndex, 1)
     this.shownDatasets = shownDatasets
+  }
+
+  async exportDataset (event: Event): Promise<void> {
+    const detail = (event as CustomEvent).detail
+
+    const filePath = await save({
+      title: 'Export dataset in CSV format...',
+      filters: [{
+        name: '*.csv',
+        extensions: ['csv']
+      }],
+      defaultPath: 'dataset_name_here'
+    })
+    if (filePath === null) return
+
+    console.log('exporting csv dataset to', filePath)
+    aeonState.sketch.observations.exportDataset(detail.id, filePath)
   }
 
   render (): TemplateResult {

--- a/src/html/component-editor/observations-editor/observations-set/observations-set.ts
+++ b/src/html/component-editor/observations-editor/observations-set/observations-set.ts
@@ -8,7 +8,7 @@ import { appWindow, WebviewWindow } from '@tauri-apps/api/window'
 import { type Event as TauriEvent } from '@tauri-apps/api/helpers/event'
 import { checkboxColumn, dataCell, loadTabulatorPlugins, idColumn, nameColumn, tabulatorOptions, indexColumn } from '../tabulator-utility'
 import { icon } from '@fortawesome/fontawesome-svg-core'
-import { faAdd, faEdit, faTrash } from '@fortawesome/free-solid-svg-icons'
+import { faAdd, faEdit, faTrash, faFileArrowDown } from '@fortawesome/free-solid-svg-icons'
 
 @customElement('observations-set')
 export default class ObservationsSet extends LitElement {
@@ -249,9 +249,26 @@ export default class ObservationsSet extends LitElement {
     }))
   }
 
+  exportDataset (): void {
+    this.dispatchEvent(new CustomEvent('export-dataset', {
+      detail: {
+        id: this.data.id
+      },
+      bubbles: true,
+      composed: true
+    }))
+  }
+
   render (): TemplateResult {
     return html`
       <div class="uk-flex uk-flex-row uk-flex-right uk-margin-small-bottom">
+        <button class="uk-button uk-button-small uk-button-secondary"
+                @click=${this.exportDataset}>
+          <div class="button-label">
+            ${icon(faFileArrowDown).node}
+            Export dataset
+          </div>
+        </button>
         <button class="uk-button uk-button-small uk-button-secondary"
                 @click=${this.editDataset}>
           <div class="button-label">

--- a/src/html/component-editor/regulations-editor/regulations-editor.ts
+++ b/src/html/component-editor/regulations-editor/regulations-editor.ts
@@ -11,6 +11,7 @@ import { appWindow, WebviewWindow } from '@tauri-apps/api/window'
 import { type Event as TauriEvent } from '@tauri-apps/api/event'
 import { ContentData, ElementType, type IRegulationData, type IVariableData } from '../../util/data-interfaces'
 import _ from 'lodash'
+import { aeonState } from '../../../aeon_state'
 
 /** Component responsible for the regulations editor of the editor session. */
 @customElement('regulations-editor')
@@ -53,6 +54,8 @@ export class RegulationsEditor extends LitElement {
     window.addEventListener('focus-function-field', () => {
       this.toggleMenu(ElementType.NONE)
     })
+    // listener to export png event from editor menu
+    window.addEventListener('export-png', this.exportNetworkToPng.bind(this))
 
     // further cytoscape setup
     this.editorElement = document.createElement('div')
@@ -327,6 +330,20 @@ export class RegulationsEditor extends LitElement {
     const toLeft = this.lastTabCount < tabCount
     this.lastTabCount = tabCount
     this.cy?.panBy({ x: (toLeft ? -1 : 1) * (this.cy?.width() / (tabCount * 2)), y: 0 })
+  }
+
+  /** Export the network to PNG and return it in base64. */
+  private exportNetworkToPng (event: Event): void {
+    const path = (event as CustomEvent).detail.path
+
+    const pngBase64 = this.cy?.png({
+      full: true,
+      bg: '#ffffff',
+      output: 'base64'
+    })
+    if (pngBase64 === undefined) return
+    console.log('exporting network png to', path)
+    aeonState.sketch.exportNetworkPng(path, pngBase64)
   }
 
   /** Render context menu for the selected node. */


### PR DESCRIPTION
This PR adds two new, smaller export features. Users can now export the network into a PNG and the datasets as CSV.

The network can be exported by selecting the new option _Export network PNG_ in the main menu. The exported image should contain all the details visible on the front end. See an example below:

<img src="https://github.com/user-attachments/assets/d21efefb-5713-46b7-928f-8bd96d7e339a" alt="network" width="400"/>

Datasets can now also be exported into CSV files. The format is the same as the one we use for loading datasets. The export button is located next to the other buttons just above the dataset table, as shown below:

<img src="https://github.com/user-attachments/assets/b0532e80-4af4-4c15-9e41-6d488fdfa98d" alt="dataset" width="400"/>

Lastly, some more tests were added for dataset loading.