### PR TITLE
Tooltip help and UI improvements for property templates

### DIFF
--- a/data/test_data/test_model.json
+++ b/data/test_data/test_model.json
@@ -155,7 +155,7 @@
   "stat_properties": [
     {
       "id": "essentiality_D_D",
-      "name": "Regulation essentiality property",
+      "name": "Regulation essential (generated)",
       "annotation": "",
       "variant": "RegulationEssential",
       "input": "D",
@@ -165,7 +165,7 @@
     },
     {
       "id": "essentiality_A_C",
-      "name": "Regulation essentiality property",
+      "name": "Regulation essential (generated)",
       "annotation": "",
       "variant": "RegulationEssential",
       "input": "A",
@@ -175,7 +175,7 @@
     },
     {
       "id": "monotonicity_B_C",
-      "name": "Regulation monotonicity property",
+      "name": "Regulation monotonic (generated)",
       "annotation": "",
       "variant": "RegulationMonotonic",
       "input": "B",
@@ -185,7 +185,7 @@
     },
     {
       "id": "monotonicity_A_C",
-      "name": "Regulation monotonicity property",
+      "name": "Regulation monotonic (generated)",
       "annotation": "",
       "variant": "RegulationMonotonic",
       "input": "A",
@@ -195,7 +195,7 @@
     },
     {
       "id": "essentiality_C_C",
-      "name": "Regulation essentiality property",
+      "name": "Regulation essential (generated)",
       "annotation": "",
       "variant": "RegulationEssential",
       "input": "C",
@@ -205,7 +205,7 @@
     },
     {
       "id": "essentiality_B_C",
-      "name": "Regulation essentiality property",
+      "name": "Regulation essential (generated)",
       "annotation": "",
       "variant": "RegulationEssential",
       "input": "B",
@@ -215,7 +215,7 @@
     },
     {
       "id": "monotonicity_A_B",
-      "name": "Regulation monotonicity property",
+      "name": "Regulation monotonic (generated)",
       "annotation": "",
       "variant": "RegulationMonotonic",
       "input": "A",
@@ -225,7 +225,7 @@
     },
     {
       "id": "monotonicity_D_B",
-      "name": "Regulation monotonicity property",
+      "name": "Regulation monotonic (generated)",
       "annotation": "",
       "variant": "RegulationMonotonic",
       "input": "D",
@@ -235,7 +235,7 @@
     },
     {
       "id": "essentiality_D_B",
-      "name": "Regulation essentiality property",
+      "name": "Regulation essential (generated)",
       "annotation": "",
       "variant": "RegulationEssential",
       "input": "D",
@@ -245,7 +245,7 @@
     },
     {
       "id": "monotonicity_C_C",
-      "name": "Regulation monotonicity property",
+      "name": "Regulation monotonic (generated)",
       "annotation": "",
       "variant": "RegulationMonotonic",
       "input": "C",
@@ -255,7 +255,7 @@
     },
     {
       "id": "essentiality_A_B",
-      "name": "Regulation essentiality property",
+      "name": "Regulation essential (generated)",
       "annotation": "",
       "variant": "RegulationEssential",
       "input": "A",

--- a/data/test_data/test_model_with_data.aeon
+++ b/data/test_data/test_model_with_data.aeon
@@ -18,17 +18,17 @@ $C: A & g(C, B)
 #!function:f:#`{"id":"f","name":"f","annotation":"","arguments":[["Unknown","Unknown"],["Unknown","Unknown"]],"expression":""}`#
 #!function:g:#`{"id":"g","name":"g","annotation":"","arguments":[["Unknown","Unknown"],["Unknown","Unknown"]],"expression":""}`#
 #!function:h:#`{"id":"h","name":"h","annotation":"","arguments":[["Unknown","Unknown"]],"expression":""}`#
-#!static_property:essentiality_A_B:#`{"id":"essentiality_A_B","name":"Regulation essentiality property","annotation":"","variant":"RegulationEssential","input":"A","target":"B","value":"True","context":null}`#
-#!static_property:essentiality_A_C:#`{"id":"essentiality_A_C","name":"Regulation essentiality property","annotation":"","variant":"RegulationEssential","input":"A","target":"C","value":"True","context":null}`#
-#!static_property:essentiality_B_C:#`{"id":"essentiality_B_C","name":"Regulation essentiality property","annotation":"","variant":"RegulationEssential","input":"B","target":"C","value":"True","context":null}`#
-#!static_property:essentiality_C_C:#`{"id":"essentiality_C_C","name":"Regulation essentiality property","annotation":"","variant":"RegulationEssential","input":"C","target":"C","value":"True","context":null}`#
-#!static_property:essentiality_D_B:#`{"id":"essentiality_D_B","name":"Regulation essentiality property","annotation":"","variant":"RegulationEssential","input":"D","target":"B","value":"True","context":null}`#
-#!static_property:essentiality_D_D:#`{"id":"essentiality_D_D","name":"Regulation essentiality property","annotation":"","variant":"RegulationEssential","input":"D","target":"D","value":"True","context":null}`#
-#!static_property:monotonicity_A_B:#`{"id":"monotonicity_A_B","name":"Regulation monotonicity property","annotation":"","variant":"RegulationMonotonic","input":"A","target":"B","value":"Activation","context":null}`#
-#!static_property:monotonicity_A_C:#`{"id":"monotonicity_A_C","name":"Regulation monotonicity property","annotation":"","variant":"RegulationMonotonic","input":"A","target":"C","value":"Activation","context":null}`#
-#!static_property:monotonicity_B_C:#`{"id":"monotonicity_B_C","name":"Regulation monotonicity property","annotation":"","variant":"RegulationMonotonic","input":"B","target":"C","value":"Activation","context":null}`#
-#!static_property:monotonicity_C_C:#`{"id":"monotonicity_C_C","name":"Regulation monotonicity property","annotation":"","variant":"RegulationMonotonic","input":"C","target":"C","value":"Inhibition","context":null}`#
-#!static_property:monotonicity_D_B:#`{"id":"monotonicity_D_B","name":"Regulation monotonicity property","annotation":"","variant":"RegulationMonotonic","input":"D","target":"B","value":"Activation","context":null}`#
+#!static_property:essentiality_A_B:#`{"id":"essentiality_A_B","name":"Regulation essential (generated)","annotation":"","variant":"RegulationEssential","input":"A","target":"B","value":"True","context":null}`#
+#!static_property:essentiality_A_C:#`{"id":"essentiality_A_C","name":"Regulation essential (generated)","annotation":"","variant":"RegulationEssential","input":"A","target":"C","value":"True","context":null}`#
+#!static_property:essentiality_B_C:#`{"id":"essentiality_B_C","name":"Regulation essential (generated)","annotation":"","variant":"RegulationEssential","input":"B","target":"C","value":"True","context":null}`#
+#!static_property:essentiality_C_C:#`{"id":"essentiality_C_C","name":"Regulation essential (generated)","annotation":"","variant":"RegulationEssential","input":"C","target":"C","value":"True","context":null}`#
+#!static_property:essentiality_D_B:#`{"id":"essentiality_D_B","name":"Regulation essential (generated)","annotation":"","variant":"RegulationEssential","input":"D","target":"B","value":"True","context":null}`#
+#!static_property:essentiality_D_D:#`{"id":"essentiality_D_D","name":"Regulation essential (generated)","annotation":"","variant":"RegulationEssential","input":"D","target":"D","value":"True","context":null}`#
+#!static_property:monotonicity_A_B:#`{"id":"monotonicity_A_B","name":"Regulation monotonic (generated)","annotation":"","variant":"RegulationMonotonic","input":"A","target":"B","value":"Activation","context":null}`#
+#!static_property:monotonicity_A_C:#`{"id":"monotonicity_A_C","name":"Regulation monotonic (generated)","annotation":"","variant":"RegulationMonotonic","input":"A","target":"C","value":"Activation","context":null}`#
+#!static_property:monotonicity_B_C:#`{"id":"monotonicity_B_C","name":"Regulation monotonic (generated)","annotation":"","variant":"RegulationMonotonic","input":"B","target":"C","value":"Activation","context":null}`#
+#!static_property:monotonicity_C_C:#`{"id":"monotonicity_C_C","name":"Regulation monotonic (generated)","annotation":"","variant":"RegulationMonotonic","input":"C","target":"C","value":"Inhibition","context":null}`#
+#!static_property:monotonicity_D_B:#`{"id":"monotonicity_D_B","name":"Regulation monotonic (generated)","annotation":"","variant":"RegulationMonotonic","input":"D","target":"B","value":"Activation","context":null}`#
 #!variable:A:#`{"id":"A","name":"A","annotation":"","update_fn":"h(C)"}`#
 #!variable:B:#`{"id":"B","name":"B","annotation":"","update_fn":"f(A, D)"}`#
 #!variable:C:#`{"id":"C","name":"C","annotation":"","update_fn":"A & g(C, B)"}`#

--- a/data/test_data/test_model_with_data.json
+++ b/data/test_data/test_model_with_data.json
@@ -250,7 +250,7 @@
   "stat_properties": [
     {
       "id": "essentiality_A_B",
-      "name": "Regulation essentiality property",
+      "name": "Regulation essential (generated)",
       "annotation": "",
       "variant": "RegulationEssential",
       "input": "A",
@@ -260,7 +260,7 @@
     },
     {
       "id": "essentiality_D_D",
-      "name": "Regulation essentiality property",
+      "name": "Regulation essential (generated)",
       "annotation": "",
       "variant": "RegulationEssential",
       "input": "D",
@@ -270,7 +270,7 @@
     },
     {
       "id": "essentiality_D_B",
-      "name": "Regulation essentiality property",
+      "name": "Regulation essential (generated)",
       "annotation": "",
       "variant": "RegulationEssential",
       "input": "D",
@@ -280,7 +280,7 @@
     },
     {
       "id": "monotonicity_B_C",
-      "name": "Regulation monotonicity property",
+      "name": "Regulation monotonic (generated)",
       "annotation": "",
       "variant": "RegulationMonotonic",
       "input": "B",
@@ -290,7 +290,7 @@
     },
     {
       "id": "essentiality_C_C",
-      "name": "Regulation essentiality property",
+      "name": "Regulation essential (generated)",
       "annotation": "",
       "variant": "RegulationEssential",
       "input": "C",
@@ -300,7 +300,7 @@
     },
     {
       "id": "essentiality_B_C",
-      "name": "Regulation essentiality property",
+      "name": "Regulation essential (generated)",
       "annotation": "",
       "variant": "RegulationEssential",
       "input": "B",
@@ -310,7 +310,7 @@
     },
     {
       "id": "monotonicity_C_C",
-      "name": "Regulation monotonicity property",
+      "name": "Regulation monotonic (generated)",
       "annotation": "",
       "variant": "RegulationMonotonic",
       "input": "C",
@@ -320,7 +320,7 @@
     },
     {
       "id": "monotonicity_A_B",
-      "name": "Regulation monotonicity property",
+      "name": "Regulation monotonic (generated)",
       "annotation": "",
       "variant": "RegulationMonotonic",
       "input": "A",
@@ -330,7 +330,7 @@
     },
     {
       "id": "essentiality_A_C",
-      "name": "Regulation essentiality property",
+      "name": "Regulation essential (generated)",
       "annotation": "",
       "variant": "RegulationEssential",
       "input": "A",
@@ -340,7 +340,7 @@
     },
     {
       "id": "monotonicity_D_B",
-      "name": "Regulation monotonicity property",
+      "name": "Regulation monotonic (generated)",
       "annotation": "",
       "variant": "RegulationMonotonic",
       "input": "D",
@@ -350,7 +350,7 @@
     },
     {
       "id": "monotonicity_A_C",
-      "name": "Regulation monotonicity property",
+      "name": "Regulation monotonic (generated)",
       "annotation": "",
       "variant": "RegulationMonotonic",
       "input": "A",

--- a/src-tauri/src/sketchbook/properties/dynamic_props/_dynamic_property.rs
+++ b/src-tauri/src/sketchbook/properties/dynamic_props/_dynamic_property.rs
@@ -136,37 +136,44 @@ impl DynProperty {
 
     /// Create default "generic" `DynProperty` instance, representing "true" formula.
     pub fn default_generic() -> DynProperty {
-        Self::try_mk_generic("Generic dynamic property", "true", "").unwrap()
+        Self::try_mk_generic("New generic dynamic property", "true", "").unwrap()
     }
 
     /// Create default `DynProperty` instance for the existence of a fixed point, with empty
     /// `dataset` and `observation` fields.
     pub fn default_fixed_point() -> DynProperty {
-        Self::mk_fixed_point("Fixed point existence", None, None, "")
+        Self::mk_fixed_point("New exist fixed points property", None, None, "")
     }
 
     /// Create default `DynProperty` instance for the existence of a trap space, with empty
     /// `dataset` and `observation` fields, and all flags set to false.
     pub fn default_trap_space() -> DynProperty {
-        Self::mk_trap_space("Trap space existence", None, None, false, false, "")
+        Self::mk_trap_space(
+            "New exist trap spaces property",
+            None,
+            None,
+            false,
+            false,
+            "",
+        )
     }
 
     /// Create default `DynProperty` instance for the existence of a trajectory, with an empty
     /// `dataset`field.
     pub fn default_trajectory() -> DynProperty {
-        Self::mk_trajectory("Trajectory existence", None, "")
+        Self::mk_trajectory("New exist trajectory property", None, "")
     }
 
     /// Create default `DynProperty` instance for the number of existing attractors, with default
     /// count being 1.
     pub fn default_attractor_count() -> DynProperty {
-        Self::try_mk_attractor_count("Attractor count", 1, 1, "").unwrap()
+        Self::try_mk_attractor_count("New attractor count property", 1, 1, "").unwrap()
     }
 
     /// Create default `DynProperty` instance for the existence of an attractor with empty
     /// `dataset` and `observation` fields.
     pub fn default_has_attractor() -> DynProperty {
-        Self::mk_has_attractor("Attractor existence", None, None, "")
+        Self::mk_has_attractor("New exist attractors property", None, None, "")
     }
 }
 

--- a/src-tauri/src/sketchbook/properties/shortcuts.rs
+++ b/src-tauri/src/sketchbook/properties/shortcuts.rs
@@ -19,7 +19,7 @@ pub fn mk_essentiality_prop(
     target: &VarId,
     essentiality: Essentiality,
 ) -> StatProperty {
-    let name_str = "Regulation essentiality property";
+    let name_str = "Regulation essential (generated)";
     StatProperty::mk_regulation_essential(
         name_str,
         Some(regulator.clone()),
@@ -37,7 +37,7 @@ pub fn mk_monotonicity_prop(
     target: &VarId,
     monotonicity: Monotonicity,
 ) -> StatProperty {
-    let name_str = "Regulation monotonicity property";
+    let name_str = "Regulation monotonic (generated)";
     StatProperty::mk_regulation_monotonic(
         name_str,
         Some(regulator.clone()),

--- a/src-tauri/src/sketchbook/properties/static_props/_static_property.rs
+++ b/src-tauri/src/sketchbook/properties/static_props/_static_property.rs
@@ -231,7 +231,7 @@ impl StatProperty {
     /// `target` fields and `Unknown` essentiality).
     pub fn default_regulation_essential() -> StatProperty {
         Self::mk_regulation_essential(
-            "Regulation essential",
+            "Regulation essential (generated)",
             None,
             None,
             Essentiality::Unknown,
@@ -256,7 +256,7 @@ impl StatProperty {
     /// `target` fields and `Unknown` monotonicity).
     pub fn default_regulation_monotonic() -> StatProperty {
         Self::mk_regulation_monotonic(
-            "Regulation monotonic",
+            "Regulation monotonic (generated)",
             None,
             None,
             Monotonicity::Unknown,
@@ -281,7 +281,7 @@ impl StatProperty {
     /// and `target` fields and `Unknown` essentiality).
     pub fn default_fn_input_essential() -> StatProperty {
         Self::mk_fn_input_essential(
-            "Function input essential",
+            "Function input essential (generated)",
             None,
             None,
             Essentiality::Unknown,
@@ -306,7 +306,7 @@ impl StatProperty {
     /// and `target` fields and `Unknown` monotonicity).
     pub fn default_fn_input_monotonic() -> StatProperty {
         Self::mk_fn_input_monotonic(
-            "Function input monotonic",
+            "Function input monotonic (generated)",
             None,
             None,
             Monotonicity::Unknown,

--- a/src-tauri/src/sketchbook/properties/static_props/_static_property.rs
+++ b/src-tauri/src/sketchbook/properties/static_props/_static_property.rs
@@ -224,7 +224,7 @@ impl StatProperty {
 
     /// Create default "generic" `StatProperty` instance, representing "true" formula.
     pub fn default_generic() -> StatProperty {
-        Self::try_mk_generic("Generic static property", "true", "").unwrap()
+        Self::try_mk_generic("New generic static property", "true", "").unwrap()
     }
 
     /// Create default `StatProperty` instance for regulation essentiality (with empty `input` and
@@ -243,7 +243,7 @@ impl StatProperty {
     /// (with empty `input`, `target`, and `context` fields and `Unknown` essentiality).
     pub fn default_regulation_essential_context() -> StatProperty {
         Self::mk_regulation_essential_context(
-            "Regulation essential",
+            "New regulation essential property",
             None,
             None,
             Essentiality::Unknown,
@@ -268,7 +268,7 @@ impl StatProperty {
     /// (with empty `input`, `target`, and `context` fields and `Unknown` monotonicity).
     pub fn default_regulation_monotonic_context() -> StatProperty {
         Self::mk_regulation_monotonic_context(
-            "Regulation monotonic",
+            "New regulation monotonic property",
             None,
             None,
             Monotonicity::Unknown,
@@ -293,7 +293,7 @@ impl StatProperty {
     /// (with empty `input`, `target`, and `context` fields and `Unknown` essentiality).
     pub fn default_fn_input_essential_context() -> StatProperty {
         Self::mk_fn_input_essential_context(
-            "Function input essential",
+            "New function input essential property",
             None,
             None,
             Essentiality::Unknown,
@@ -318,7 +318,7 @@ impl StatProperty {
     /// (with empty `input`, `target`, and `context` fields and `Unknown` monotonicity).
     pub fn default_fn_input_monotonic_context() -> StatProperty {
         Self::mk_fn_input_monotonic_context(
-            "Function input monotonic",
+            "New function input monotonic property",
             None,
             None,
             Monotonicity::Unknown,

--- a/src/html/component-editor/properties-editor/abstract-property/abstract-property.less
+++ b/src/html/component-editor/properties-editor/abstract-property/abstract-property.less
@@ -25,10 +25,6 @@
   width: 100%;
 }
 
-.uk-form-label {
-  color: @text-light;
-}
-
 .nameplate {
   width: 100%;
 }
@@ -47,11 +43,44 @@
   font-family: monospace;
 }
 
-.static-name-field {
-  color: @text-light;
+.tooltip {
+  position: relative;
+  display: inline-block;
 }
 
-@media (prefers-color-scheme: dark) {  
+.tooltip .tooltiptext {
+  visibility: hidden;
+  font-size: smaller;
+  text-align: center;
+  padding: 3px 5px;
+  border-radius: 3px;
+
+  position: absolute;
+  left: 30px;
+}
+
+/* Show the tooltip text when you mouse over the tooltip container */
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+}
+
+@media (prefers-color-scheme: light) {
+  .tooltip .tooltiptext {
+    // make tooltip for light mode darker color
+    background-color: @background-dark;
+    color: @text-dark;
+  }
+
+  .static-name-field {
+    color: @text-light;
+  }
+
+  .uk-form-label {
+    color: @text-light;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
   .static-name-field {
     color: @text-dark;
   }
@@ -59,5 +88,10 @@
   .uk-form-label {
     color: @text-dark;
   }
-}
 
+  .tooltip .tooltiptext {
+    // make tooltip for dark mode lighter color
+    background-color: @background-light;
+    color: @text-light;
+  }
+}

--- a/src/html/component-editor/properties-editor/dynamic/abstract-dynamic-property.ts
+++ b/src/html/component-editor/properties-editor/dynamic/abstract-dynamic-property.ts
@@ -1,11 +1,11 @@
 import { type DynamicProperty, type StaticProperty } from '../../../util/data-interfaces'
 import { debounce } from 'lodash'
 import AbstractProperty from '../abstract-property/abstract-property'
-import { faTrash, faEdit } from '@fortawesome/free-solid-svg-icons'
+import { faTrash, faEdit, faCircleInfo } from '@fortawesome/free-solid-svg-icons'
 import { icon } from '@fortawesome/fontawesome-svg-core'
 import { html, type TemplateResult } from 'lit'
 import { functionDebounceTimer } from '../../../util/config'
-import { formatTemplateName } from '../../../util/utilities'
+import { formatTemplateName, getTemplateHelpText } from '../../../util/utilities'
 
 const EVENT_PROPERTY_CHANGED = 'dynamic-property-changed'
 const EVENT_PROPERTY_ID_CHANGED = 'dynamic-property-id-changed'
@@ -37,6 +37,10 @@ export default class AbstractDynamicProperty extends AbstractProperty {
     return html`
       <div class="uk-margin-bottom uk-margin-remove-bottom" style="font-size:large;">
         ${formatTemplateName(this.property.variant)}
+        <span class="tooltip" style="font-size:medium;">
+          ${icon(faCircleInfo).node}
+          <span class="tooltiptext">${getTemplateHelpText(this.property.variant)}</span>
+        </span>
       </div>
       <div class="uk-flex uk-flex-row uk-flex-bottom uk-width-auto">
         <div class="uk-flex uk-flex-column">

--- a/src/html/component-editor/properties-editor/dynamic/abstract-dynamic-property.ts
+++ b/src/html/component-editor/properties-editor/dynamic/abstract-dynamic-property.ts
@@ -5,6 +5,7 @@ import { faTrash, faEdit } from '@fortawesome/free-solid-svg-icons'
 import { icon } from '@fortawesome/fontawesome-svg-core'
 import { html, type TemplateResult } from 'lit'
 import { functionDebounceTimer } from '../../../util/config'
+import { formatTemplateName } from '../../../util/utilities'
 
 const EVENT_PROPERTY_CHANGED = 'dynamic-property-changed'
 const EVENT_PROPERTY_ID_CHANGED = 'dynamic-property-id-changed'
@@ -34,6 +35,9 @@ export default class AbstractDynamicProperty extends AbstractProperty {
 
   renderNameplate (): TemplateResult {
     return html`
+      <div class="uk-margin-bottom uk-margin-remove-bottom" style="font-size:large;">
+        ${formatTemplateName(this.property.variant)}
+      </div>
       <div class="uk-flex uk-flex-row uk-flex-bottom uk-width-auto">
         <div class="uk-flex uk-flex-column">
           <label class="uk-form-label" for="id-field">ID</label>

--- a/src/html/component-editor/properties-editor/dynamic/dynamic-attractor-count/dynamic-attractor-count.ts
+++ b/src/html/component-editor/properties-editor/dynamic/dynamic-attractor-count/dynamic-attractor-count.ts
@@ -99,7 +99,6 @@ export default class DynamicAttractorCount extends AbstractDynamicProperty {
               </div>`)}
 
       </div>
-      <hr class="uk-margin-top uk-margin-bottom uk-margin-left uk-margin-right">
     `
   }
 }

--- a/src/html/component-editor/properties-editor/dynamic/dynamic-generic/dynamic-generic.less
+++ b/src/html/component-editor/properties-editor/dynamic/dynamic-generic/dynamic-generic.less
@@ -1,6 +1,16 @@
 @import "../../abstract-property/abstract-property";
 
-
 .remove-property {
-    height: 40px;
+  height: 40px;
+}
+
+.value-label {
+  .uk-form-label;
+  .uk-text-left;
+}
+
+@media (prefers-color-scheme: dark) {
+  .value-label {
+    color: @text-dark;
   }
+}

--- a/src/html/component-editor/properties-editor/dynamic/dynamic-generic/dynamic-generic.ts
+++ b/src/html/component-editor/properties-editor/dynamic/dynamic-generic/dynamic-generic.ts
@@ -30,7 +30,6 @@ export default class DynamicGeneric extends AbstractDynamicProperty {
         <input id="value-editor" class="uk-input" .value="${this.property.formula}"
                @focusout="${this.handleFocusOut}">
       </div>
-      <hr class="uk-margin-top uk-margin-bottom uk-margin-left uk-margin-right">
     `
   }
 }

--- a/src/html/component-editor/properties-editor/dynamic/dynamic-generic/dynamic-generic.ts
+++ b/src/html/component-editor/properties-editor/dynamic/dynamic-generic/dynamic-generic.ts
@@ -27,8 +27,13 @@ export default class DynamicGeneric extends AbstractDynamicProperty {
     return html`
       <div class="property-body">
         ${this.renderNameplate()}
-        <input id="value-editor" class="uk-input" .value="${this.property.formula}"
+        <div class="uk-flex uk-flex-column uk-flex-left">
+          <label class="value-label">HCTL formula:</label>
+          <div class="uk-flex uk-flex-row">
+            <input id="value-editor" class="uk-input" .value="${this.property.formula}"
                @focusout="${this.handleFocusOut}">
+          </div>
+        </div>
       </div>
     `
   }

--- a/src/html/component-editor/properties-editor/dynamic/dynamic-obs-selection/dynamic-obs-selection.ts
+++ b/src/html/component-editor/properties-editor/dynamic/dynamic-obs-selection/dynamic-obs-selection.ts
@@ -113,7 +113,6 @@ export default class DynamicObsSelection extends AbstractDynamicProperty {
             </div>
           </div>`)}
       </div>
-      <hr class="uk-margin-top uk-margin-bottom uk-margin-left uk-margin-right">
     `
   }
 }

--- a/src/html/component-editor/properties-editor/properties-editor.less
+++ b/src/html/component-editor/properties-editor/properties-editor.less
@@ -65,6 +65,38 @@
   background: @secondary-light;
 }
 
+.tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+/* Tooltip text */
+.tooltip .tooltiptext {
+  visibility: hidden;
+  font-size: smaller;
+  text-align: center;
+  padding: 3px 5px;
+  border-radius: 3px;
+
+  position: absolute;
+  right: 115%;
+}
+
+/* Show the tooltip text when you mouse over the tooltip container */
+.tooltip:hover .tooltiptext {
+  visibility: visible;
+}
+
+.tooltip .tooltiptext::after {
+  content: " ";
+  position: absolute;
+  top: 50%;
+  left: 100%; /* To the right of the tooltip */
+  margin-top: -5px;
+  border-width: 5px;
+  border-style: solid;
+}
+
 @media (prefers-color-scheme: dark) {
   .menu-content {
     background-color: @background-dark;
@@ -77,6 +109,17 @@
   .menu-item:hover {
     background: @secondary-dark;
   }
+
+  .tooltip .tooltiptext {
+    // make tooltip for dark mode lighter color
+    background-color: @background-light;
+    color: @text-light;
+  }
+
+  .tooltip .tooltiptext::after {
+    // make tooltip for dark mode lighter color
+    border-color: transparent transparent transparent @background-light;
+  }
 }
 
 @media (prefers-color-scheme: light) {
@@ -86,6 +129,17 @@
 
   .menu-item > a {
     color: @text-light;
+  }
+
+  .tooltip .tooltiptext {
+    // make tooltip for light mode darker color
+    background-color: @background-dark;
+    color: @text-dark;
+  }
+
+  .tooltip .tooltiptext::after {
+    // make tooltip for light mode darker color
+    border-color: transparent transparent transparent @background-dark;
   }
 }
 

--- a/src/html/component-editor/properties-editor/properties-editor.less
+++ b/src/html/component-editor/properties-editor/properties-editor.less
@@ -79,7 +79,7 @@
   border-radius: 3px;
 
   position: absolute;
-  right: 115%;
+  right: 112%;
 }
 
 /* Show the tooltip text when you mouse over the tooltip container */
@@ -120,6 +120,11 @@
     // make tooltip for dark mode lighter color
     border-color: transparent transparent transparent @background-light;
   }
+
+  hr {
+    // make hr for dark mode lighter color
+    background-color: @background-light;
+  }  
 }
 
 @media (prefers-color-scheme: light) {
@@ -141,6 +146,11 @@
     // make tooltip for light mode darker color
     border-color: transparent transparent transparent @background-dark;
   }
+
+  hr {
+    // make hr for light mode darker color
+    background-color: @background-dark;
+  }  
 }
 
 @container property-list (max-width: 64em) {
@@ -154,4 +164,9 @@
     justify-content: unset;
     align-items: center;
   }
+}
+
+hr {
+  height: 1px;
+  border:none
 }

--- a/src/html/component-editor/properties-editor/properties-editor.less
+++ b/src/html/component-editor/properties-editor/properties-editor.less
@@ -65,13 +65,12 @@
   background: @secondary-light;
 }
 
-.tooltip {
+.menu-tooltip {
   position: relative;
   display: inline-block;
 }
 
-/* Tooltip text */
-.tooltip .tooltiptext {
+.menu-tooltip .menu-tooltiptext {
   visibility: hidden;
   font-size: smaller;
   text-align: center;
@@ -83,11 +82,11 @@
 }
 
 /* Show the tooltip text when you mouse over the tooltip container */
-.tooltip:hover .tooltiptext {
+.menu-tooltip:hover .menu-tooltiptext {
   visibility: visible;
 }
 
-.tooltip .tooltiptext::after {
+.menu-tooltip .menu-tooltiptext::after {
   content: " ";
   position: absolute;
   top: 50%;
@@ -110,13 +109,13 @@
     background: @secondary-dark;
   }
 
-  .tooltip .tooltiptext {
+  .menu-tooltip .menu-tooltiptext {
     // make tooltip for dark mode lighter color
     background-color: @background-light;
     color: @text-light;
   }
 
-  .tooltip .tooltiptext::after {
+  .menu-tooltip .menu-tooltiptext::after {
     // make tooltip for dark mode lighter color
     border-color: transparent transparent transparent @background-light;
   }
@@ -136,13 +135,13 @@
     color: @text-light;
   }
 
-  .tooltip .tooltiptext {
+  .menu-tooltip .menu-tooltiptext {
     // make tooltip for light mode darker color
     background-color: @background-dark;
     color: @text-dark;
   }
 
-  .tooltip .tooltiptext::after {
+  .menu-tooltip .menu-tooltiptext::after {
     // make tooltip for light mode darker color
     border-color: transparent transparent transparent @background-dark;
   }

--- a/src/html/component-editor/properties-editor/properties-editor.ts
+++ b/src/html/component-editor/properties-editor/properties-editor.ts
@@ -15,7 +15,6 @@ import {
   ContentData,
   type DynamicProperty,
   DynamicPropertyType,
-  type PropertyType,
   type StaticProperty,
   StaticPropertyType
 } from '../../util/data-interfaces'
@@ -24,7 +23,7 @@ import { computePosition, flip } from '@floating-ui/dom'
 import { aeonState, type DynPropIdUpdateData, type StatPropIdUpdateData } from '../../../aeon_state'
 import { appWindow, WebviewWindow } from '@tauri-apps/api/window'
 import { type Event as TauriEvent } from '@tauri-apps/api/helpers/event'
-import { formatTemplateName } from '../../util/utilities'
+import { formatTemplateName, getTemplateHelpText } from '../../util/utilities'
 
 /** Component responsible for the properties editor of the editor session. */
 @customElement('properties-editor')
@@ -44,45 +43,21 @@ export default class PropertiesEditor extends LitElement {
   // dynamic prop edit dialogs
   dialogsDynamic: Record<string, WebviewWindow | undefined> = {}
 
-  addDynamicPropertyMenu: IAddPropertyItem[] = [
-    {
-      type: DynamicPropertyType.TrapSpace,
-      help: 'Each selected observation exists in a trap space.'
-    }, {
-      type: DynamicPropertyType.FixedPoint,
-      help: 'Each selected observation exists in a fixed point.'
-    }, {
-      type: DynamicPropertyType.ExistsTrajectory,
-      help: 'Observations of selected dataset lay on a trajectory.'
-    }, {
-      type: DynamicPropertyType.AttractorCount,
-      help: 'Attractor count falls into a given range.'
-    }, {
-      type: DynamicPropertyType.HasAttractor,
-      help: 'Each selected observation exists in an attractor.'
-    }, {
-      type: DynamicPropertyType.Generic,
-      help: 'Generic HCTL property defined by the user.'
-    }
+  addDynamicPropertyMenu: DynamicPropertyType[] = [
+    DynamicPropertyType.TrapSpace,
+    DynamicPropertyType.FixedPoint,
+    DynamicPropertyType.ExistsTrajectory,
+    DynamicPropertyType.AttractorCount,
+    DynamicPropertyType.HasAttractor,
+    DynamicPropertyType.Generic
   ]
 
-  addStaticPropertyMenu: IAddPropertyItem[] = [
-    {
-      type: StaticPropertyType.FunctionInputEssentialWithCondition,
-      help: 'Selected function input has given essentiality.'
-    }, {
-      type: StaticPropertyType.VariableRegulationEssentialWithCondition,
-      help: 'Selected regulation has given essentiality.'
-    }, {
-      type: StaticPropertyType.FunctionInputMonotonicWithCondition,
-      help: 'Selected function input has given monotonicity.'
-    }, {
-      type: StaticPropertyType.VariableRegulationMonotonicWithCondition,
-      help: 'Selected regulation has given monotonicity.'
-    }, {
-      type: StaticPropertyType.Generic,
-      help: 'Generic FOL property defined by the user.'
-    }
+  addStaticPropertyMenu: StaticPropertyType[] = [
+    StaticPropertyType.FunctionInputEssentialWithCondition,
+    StaticPropertyType.VariableRegulationEssentialWithCondition,
+    StaticPropertyType.FunctionInputMonotonicWithCondition,
+    StaticPropertyType.VariableRegulationMonotonicWithCondition,
+    StaticPropertyType.Generic
   ]
 
   constructor () {
@@ -421,11 +396,11 @@ export default class PropertiesEditor extends LitElement {
               <ul class="uk-nav">
                 ${map(this.addDynamicPropertyMenu, (item) => html`
                   <li class="menu-item" @click="${() => {
-                    this.itemClick(() => { this.addDynamicProperty(item.type as DynamicPropertyType) })
+                    this.itemClick(() => { this.addDynamicProperty(item) })
                   }}">
-                    <a class="tooltip">
-                      ${formatTemplateName(item.type)}
-                      <span class="tooltiptext">${item.help}</span>
+                    <a class="menu-tooltip">
+                      ${formatTemplateName(item)}
+                      <span class="menu-tooltiptext">${getTemplateHelpText(item)}</span>
                     </a>
                   </li>
                 `)}
@@ -437,11 +412,11 @@ export default class PropertiesEditor extends LitElement {
               <ul class="uk-nav">
                 ${map(this.addStaticPropertyMenu, (item) => html`
                   <li class="menu-item" @click="${() => {
-                    this.itemClick(() => { this.addStaticProperty(item.type as StaticPropertyType) })
+                    this.itemClick(() => { this.addStaticProperty(item) })
                   }}">
-                    <a class="tooltip">
-                      ${formatTemplateName(item.type)}
-                      <span class="tooltiptext">${item.help}</span>
+                    <a class="menu-tooltip">
+                      ${formatTemplateName(item)}
+                      <span class="menu-tooltiptext">${getTemplateHelpText(item)}</span>
                     </a>
                   </li>
                 `)}
@@ -476,7 +451,8 @@ export default class PropertiesEditor extends LitElement {
                   case StaticPropertyType.Generic:
                     result = html`
                       <static-generic .index=${index}
-                                      .property=${prop}>
+                                      .property=${prop}
+                                      .help=${prop}>
                       </static-generic>`
                     break
                   case StaticPropertyType.FunctionInputEssential:
@@ -577,13 +553,4 @@ export default class PropertiesEditor extends LitElement {
         </div>
       </div>`
   }
-}
-
-/**
- * Template for options in the 'Add property' menu.
- * Each entry has a displayed name, a hoverable tooltip help, and action.
- */
-interface IAddPropertyItem {
-  type: PropertyType
-  help: string
 }

--- a/src/html/component-editor/properties-editor/properties-editor.ts
+++ b/src/html/component-editor/properties-editor/properties-editor.ts
@@ -45,21 +45,27 @@ export default class PropertiesEditor extends LitElement {
   addDynamicPropertyMenu: IAddPropertyItem[] = [
     {
       label: 'Exists trap space',
+      help: 'Each selected observation exists in a trap space.',
       action: () => { this.addDynamicProperty(DynamicPropertyType.TrapSpace) }
     }, {
       label: 'Exists fixed point',
+      help: 'Each selected observation exists in a fixed point.',
       action: () => { this.addDynamicProperty(DynamicPropertyType.FixedPoint) }
     }, {
       label: 'Exists trajectory',
+      help: 'Observations of selected dataset lay on a trajectory.',
       action: () => { this.addDynamicProperty(DynamicPropertyType.ExistsTrajectory) }
     }, {
       label: 'Attractor count',
+      help: 'Attractor count falls into a given range.',
       action: () => { this.addDynamicProperty(DynamicPropertyType.AttractorCount) }
     }, {
       label: 'Exists attractor',
+      help: 'Each selected observation exists in an attractor.',
       action: () => { this.addDynamicProperty(DynamicPropertyType.HasAttractor) }
     }, {
       label: 'Generic',
+      help: 'Generic HCTL property defined by the user.',
       action: () => { this.addDynamicProperty(DynamicPropertyType.Generic) }
     }
   ]
@@ -67,18 +73,23 @@ export default class PropertiesEditor extends LitElement {
   addStaticPropertyMenu: IAddPropertyItem[] = [
     {
       label: 'Function input essential',
+      help: 'Selected function input has given essentiality.',
       action: () => { this.addStaticProperty(StaticPropertyType.FunctionInputEssentialWithCondition) }
     }, {
       label: 'Regulation essential',
+      help: 'Selected regulation has given essentiality.',
       action: () => { this.addStaticProperty(StaticPropertyType.VariableRegulationEssentialWithCondition) }
     }, {
       label: 'Function input monotonic',
+      help: 'Selected function input has given monotonicity.',
       action: () => { this.addStaticProperty(StaticPropertyType.FunctionInputMonotonicWithCondition) }
     }, {
       label: 'Regulation monotonic',
+      help: 'Selected regulation has given monotonicity.',
       action: () => { this.addStaticProperty(StaticPropertyType.VariableRegulationMonotonicWithCondition) }
     }, {
       label: 'Generic',
+      help: 'Generic FOL property defined by the user.',
       action: () => { this.addStaticProperty(StaticPropertyType.Generic) }
     }
   ]
@@ -421,8 +432,9 @@ export default class PropertiesEditor extends LitElement {
                   <li class="menu-item" @click="${() => {
                     this.itemClick(item.action)
                   }}">
-                    <a>
+                    <a class="tooltip">
                       ${item.label}
+                      <span class="tooltiptext">${item.help}</span>
                     </a>
                   </li>
                 `)}
@@ -436,8 +448,9 @@ export default class PropertiesEditor extends LitElement {
                   <li class="menu-item" @click="${() => {
                     this.itemClick(item.action)
                   }}">
-                    <a>
+                    <a class="tooltip">
                       ${item.label}
+                      <span class="tooltiptext">${item.help}</span>
                     </a>
                   </li>
                 `)}
@@ -561,7 +574,12 @@ export default class PropertiesEditor extends LitElement {
   }
 }
 
+/**
+ * Template for options in the 'Add property' menu.
+ * Each entry has a displayed name, a hoverable tooltip help, and action.
+ */
 interface IAddPropertyItem {
   label: string
+  help: string
   action: () => void
 }

--- a/src/html/component-editor/properties-editor/static/static-generic/static-generic.ts
+++ b/src/html/component-editor/properties-editor/static/static-generic/static-generic.ts
@@ -28,7 +28,7 @@ export default class StaticGeneric extends abstractStaticProperty {
       <div class="property-body">
         ${this.renderNameplate()}
         <div class="uk-flex uk-flex-column uk-flex-left">
-          <label class="value-label">Context formula:</label>
+          <label class="value-label">FOL formula:</label>
           <div class="uk-flex uk-flex-row">
             <input id="value-editor" class="uk-input" .value="${this.property.formula}"
                    @focusout="${this.handleFocusOut}"/>

--- a/src/html/component-editor/properties-editor/static/static-generic/static-generic.ts
+++ b/src/html/component-editor/properties-editor/static/static-generic/static-generic.ts
@@ -35,7 +35,6 @@ export default class StaticGeneric extends abstractStaticProperty {
           </div>
         </div>
       </div>
-      <hr class="uk-margin-top uk-margin-bottom uk-margin-left uk-margin-right">
     `
   }
 }

--- a/src/html/component-editor/properties-editor/static/static-input-essential-condition/static-input-essential-condition.ts
+++ b/src/html/component-editor/properties-editor/static/static-input-essential-condition/static-input-essential-condition.ts
@@ -61,17 +61,14 @@ export default class StaticInputEssentialCondition extends StaticSelectorsProper
           <div class="value-symbol" @click="${() => {
             this.toggleEssentiality()
           }}">
-            <span>(</span>
             <span class="essentiality">
               ${getEssentialityText(this.property.value)}
             </span>
-            <span>)</span>
           </div>
         </div>
         ${this.renderConditionField()}
       </div>
       </div>
-      <hr class="uk-margin-top uk-margin-bottom uk-margin-left uk-margin-right">
     `
   }
 }

--- a/src/html/component-editor/properties-editor/static/static-input-essential/static-input-essential.ts
+++ b/src/html/component-editor/properties-editor/static/static-input-essential/static-input-essential.ts
@@ -43,16 +43,13 @@ export default class StaticInputEssential extends abstractStaticProperty {
             <div class="uk-margin-small-right">${this.property.target}</div>
           </div>
           <div class="value-symbol">
-            <span>(</span>
             <span class="essentiality">
               ${getEssentialityText(this.property.value)}
             </span>
-            <span>)</span>
           </div>
         </div>
       </div>
       </div>
-      <hr class="uk-margin-top uk-margin-bottom uk-margin-left uk-margin-right">
     `
   }
 }

--- a/src/html/component-editor/properties-editor/static/static-input-monotonic-condition/static-input-monotonic-condition.ts
+++ b/src/html/component-editor/properties-editor/static/static-input-monotonic-condition/static-input-monotonic-condition.ts
@@ -63,17 +63,14 @@ export default class StaticInputMonotonicCondition extends StaticSelectorsProper
           <div class="value-symbol" @click="${() => {
             this.toggleMonotonicity()
           }}">
-            <span>(</span>
             <span class="monotonicity ${getMonotonicityClass(this.property.value)}">
               ${this.property.value.toLowerCase()}
             </span>
-            <span>)</span>
           </div>
         </div>
         ${this.renderConditionField()}
       </div>
       </div>
-      <hr class="uk-margin-top uk-margin-bottom uk-margin-left uk-margin-right">
     `
   }
 }

--- a/src/html/component-editor/properties-editor/static/static-input-monotonic/static-input-monotonic.ts
+++ b/src/html/component-editor/properties-editor/static/static-input-monotonic/static-input-monotonic.ts
@@ -50,16 +50,13 @@ export default class StaticInputMonotonic extends abstractStaticProperty {
             <div class="uk-margin-small-right">${this.property.target}</div>
           </div>
           <div class="value-symbol">
-            <span>(</span>
             <span class="monotonicity ${getMonotonicityClass(this.property.value)}">
               ${this.property.value.toLowerCase()}
             </span>
-            <span>)</span>
           </div>
         </div>
       </div>
       </div>
-      <hr class="uk-margin-top uk-margin-bottom uk-margin-left uk-margin-right">
     `
   }
 }

--- a/src/html/util/utilities.ts
+++ b/src/html/util/utilities.ts
@@ -1,7 +1,10 @@
 import {
   Essentiality, Monotonicity, type IFunctionData,
   type IObservationSet, type IObservation, type ILayoutData,
-  type IRegulationData, type IVariableData
+  type IRegulationData, type IVariableData,
+  type PropertyType,
+  StaticPropertyType,
+  DynamicPropertyType
 } from './data-interfaces'
 import {
   type UninterpretedFnData, type VariableData, type ObservationData,
@@ -185,5 +188,39 @@ export function convertToIRegulation (regulation: RegulationData): IRegulationDa
     target: regulation.target,
     essential: regulation.essential,
     monotonicity: regulation.sign
+  }
+}
+
+/** Make a readable name string for each property template. These will be displayed
+ * on the UI side.
+ */
+export function formatTemplateName (propertyType: PropertyType): string {
+  switch (propertyType) {
+    case StaticPropertyType.FunctionInputEssential:
+    case StaticPropertyType.FunctionInputEssentialWithCondition:
+      return 'Function input essential'
+    case StaticPropertyType.FunctionInputMonotonic:
+    case StaticPropertyType.FunctionInputMonotonicWithCondition:
+      return 'Function input monotonic'
+    case StaticPropertyType.VariableRegulationEssential:
+    case StaticPropertyType.VariableRegulationEssentialWithCondition:
+      return 'Regulation essential'
+    case StaticPropertyType.VariableRegulationMonotonic:
+    case StaticPropertyType.VariableRegulationMonotonicWithCondition:
+      return 'Regulation monotonic'
+    case StaticPropertyType.Generic:
+      return 'Generic static property'
+    case DynamicPropertyType.AttractorCount:
+      return 'Attractor count'
+    case DynamicPropertyType.ExistsTrajectory:
+      return 'Exists trajectory'
+    case DynamicPropertyType.FixedPoint:
+      return 'Exist fixed points'
+    case DynamicPropertyType.TrapSpace:
+      return 'Exist trap spaces'
+    case DynamicPropertyType.HasAttractor:
+      return 'Exist attractors'
+    case DynamicPropertyType.Generic:
+      return 'Generic dynamic property'
   }
 }

--- a/src/html/util/utilities.ts
+++ b/src/html/util/utilities.ts
@@ -224,3 +224,37 @@ export function formatTemplateName (propertyType: PropertyType): string {
       return 'Generic dynamic property'
   }
 }
+
+/** Provide help text for each property template. These can be displayed
+ * as tooltips or help messages on the UI side.
+ */
+export function getTemplateHelpText (propertyType: PropertyType): string {
+  switch (propertyType) {
+    case StaticPropertyType.FunctionInputEssential:
+    case StaticPropertyType.FunctionInputEssentialWithCondition:
+      return 'Specifies whether input is essential.'
+    case StaticPropertyType.FunctionInputMonotonic:
+    case StaticPropertyType.FunctionInputMonotonicWithCondition:
+      return 'Specifies whether input has monotonic effect.'
+    case StaticPropertyType.VariableRegulationEssential:
+    case StaticPropertyType.VariableRegulationEssentialWithCondition:
+      return 'Specifies whether regulation is essential.'
+    case StaticPropertyType.VariableRegulationMonotonic:
+    case StaticPropertyType.VariableRegulationMonotonicWithCondition:
+      return 'Specifies whether regulation has monotonic effect.'
+    case StaticPropertyType.Generic:
+      return 'A generic static property defined by the user.'
+    case DynamicPropertyType.AttractorCount:
+      return 'Attractor count falls into given range.'
+    case DynamicPropertyType.ExistsTrajectory:
+      return 'Observations of selected dataset lay on trajectory.'
+    case DynamicPropertyType.FixedPoint:
+      return 'Each selected observation exists in a fixed point.'
+    case DynamicPropertyType.TrapSpace:
+      return 'Each selected observation exists in a trap space.'
+    case DynamicPropertyType.HasAttractor:
+      return 'Each selected observation exists in an attractor.'
+    case DynamicPropertyType.Generic:
+      return 'A generic HCTL property defined by the user.'
+  }
+}


### PR DESCRIPTION
This PR addresses issues with properties outlined in #66 and #67. We added a tooltip help describing individual property templates. We also added a new field with the particular property template name to each dynamic property. Some more refactoring and UI changes were also made.