### PR TITLE
Finish up supplementary function editor features and update its UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ To build a release version of the app, run `npm run tauri build`. It will create
 
 To start the application in debug mode, run `npm run tauri dev`. Note that upon startup, the application window can be unresponsive for a few seconds when using development mode. This is because the whole application is running in debug mode without any optimizations. This startup delay should be substantially reduced when using the release binaries produced by `npm run tauri build`.
 
+Also note that the debug mode is substantially slower in general. This may sometimes cause issues in complex event processing, where some actions with multiple events can exceptionally "overload" the UI (it won't show all the changes caused by the action immediately). Refreshing the UI usually helps to reload latest state from the backend. This should not happen for the release mode, as event processing is substantially faster, and processing delays are optimized for release.
+
 ### Static analysis, tests, documentation
 
 This section describes the setup and instructions for static analysis tools, testing frameworks, and documentation generation. You don't need any of these to run the application, but they are useful for development. For all the following, run the cargo commands inside `src-tauri` folder, and npm/npx commands in the main project directory.

--- a/src-tauri/src/algorithms/eval_static/encode.rs
+++ b/src-tauri/src/algorithms/eval_static/encode.rs
@@ -99,8 +99,8 @@ pub fn encode_monotonicity(
     }
 }
 
-/// Create a FOL formula encoding that uninterpreted function's argument (given by the index)
-/// has given essentiality.
+/// Create a FOL formula encoding that uninterpreted function's argument
+/// (given by its index) has given essentiality.
 pub fn encode_essentiality(
     number_inputs: usize,
     index: usize,

--- a/src-tauri/src/algorithms/eval_static/processed_props.rs
+++ b/src-tauri/src/algorithms/eval_static/processed_props.rs
@@ -33,6 +33,10 @@ impl ProcessedStatProp {
 /// Process static properties from a sketch, converting them into one of the supported
 /// `ProcessedStatProp` variants. Currently, all properties are encoded into FOL, but we
 /// might support some other preprocessing in future.
+///
+/// Since some function symbols of the sketch were unused (in any update functions) and
+/// filtered out when creating the BN, we must also get rid of any static properties referencing
+/// these symbols. Note that removing properties of unused functions has no effect on the results.
 pub fn process_static_props(
     sketch: &Sketch,
     bn: &BooleanNetwork,
@@ -43,10 +47,16 @@ pub fn process_static_props(
 
     let mut processed_props = Vec::new();
     for (id, stat_prop) in static_props {
-        // currently, everything is encoded into first-order logic (into a "generic" property)
-        let stat_prop_processed = match stat_prop.get_prop_data() {
+        // We want to remove all properties of function symbols (parameters) not present in the BN.
+        // These parameters were pruned beforehand because they are unused (redundant), and
+        // we must do the same with their properties.
+
+        // Everything else is currently encoded into first-order logic (into a "generic" property)
+        match stat_prop.get_prop_data() {
             StatPropertyType::GenericStatProp(prop) => {
-                ProcessedStatProp::mk_fol(id.as_str(), prop.processed_formula.as_str())
+                let new_prop =
+                    ProcessedStatProp::mk_fol(id.as_str(), prop.processed_formula.as_str());
+                processed_props.push(new_prop);
             }
             StatPropertyType::RegulationEssential(prop)
             | StatPropertyType::RegulationEssentialContext(prop) => {
@@ -61,7 +71,8 @@ pub fn process_static_props(
                 if let Some(context_formula) = &prop.context {
                     formula = encode_property_in_context(context_formula, &formula);
                 }
-                ProcessedStatProp::mk_fol(id.as_str(), &formula)
+                let new_prop = ProcessedStatProp::mk_fol(id.as_str(), &formula);
+                processed_props.push(new_prop);
             }
             StatPropertyType::RegulationMonotonic(prop)
             | StatPropertyType::RegulationMonotonicContext(prop) => {
@@ -76,42 +87,52 @@ pub fn process_static_props(
                 if let Some(context_formula) = &prop.context {
                     formula = encode_property_in_context(context_formula, &formula);
                 }
-                ProcessedStatProp::mk_fol(id.as_str(), &formula)
+                let new_prop = ProcessedStatProp::mk_fol(id.as_str(), &formula);
+                processed_props.push(new_prop);
             }
             StatPropertyType::FnInputEssential(prop)
             | StatPropertyType::FnInputEssentialContext(prop) => {
                 let fn_id = prop.target.clone().unwrap();
-                let input_idx = prop.input_index.unwrap();
-                let number_inputs = sketch.model.get_uninterpreted_fn_arity(&fn_id)?;
-                let mut formula = encode_essentiality(
-                    number_inputs,
-                    input_idx,
-                    fn_id.as_str(),
-                    prop.clone().value,
-                );
-                if let Some(context_formula) = &prop.context {
-                    formula = encode_property_in_context(context_formula, &formula);
+                // Only process this property if the BN contains this function symbol as its valid
+                // parameter (otherwise it was pruned out for being unused).
+                if bn.find_parameter(fn_id.as_str()).is_some() {
+                    let input_idx = prop.input_index.unwrap();
+                    let number_inputs = sketch.model.get_uninterpreted_fn_arity(&fn_id)?;
+                    let mut formula = encode_essentiality(
+                        number_inputs,
+                        input_idx,
+                        fn_id.as_str(),
+                        prop.clone().value,
+                    );
+                    if let Some(context_formula) = &prop.context {
+                        formula = encode_property_in_context(context_formula, &formula);
+                    }
+                    let new_prop = ProcessedStatProp::mk_fol(id.as_str(), &formula);
+                    processed_props.push(new_prop);
                 }
-                ProcessedStatProp::mk_fol(id.as_str(), &formula)
             }
             StatPropertyType::FnInputMonotonic(prop)
             | StatPropertyType::FnInputMonotonicContext(prop) => {
                 let fn_id = prop.target.clone().unwrap();
-                let input_idx = prop.input_index.unwrap();
-                let number_inputs = sketch.model.get_uninterpreted_fn_arity(&fn_id)?;
-                let mut formula = encode_monotonicity(
-                    number_inputs,
-                    input_idx,
-                    fn_id.as_str(),
-                    prop.clone().value,
-                );
-                if let Some(context_formula) = &prop.context {
-                    formula = encode_property_in_context(context_formula, &formula);
+                // Only process this property if the BN contains this function symbol as its valid
+                // parameter (otherwise it was pruned out for being unused).
+                if bn.find_parameter(fn_id.as_str()).is_some() {
+                    let input_idx = prop.input_index.unwrap();
+                    let number_inputs = sketch.model.get_uninterpreted_fn_arity(&fn_id)?;
+                    let mut formula = encode_monotonicity(
+                        number_inputs,
+                        input_idx,
+                        fn_id.as_str(),
+                        prop.clone().value,
+                    );
+                    if let Some(context_formula) = &prop.context {
+                        formula = encode_property_in_context(context_formula, &formula);
+                    }
+                    let new_prop = ProcessedStatProp::mk_fol(id.as_str(), &formula);
+                    processed_props.push(new_prop);
                 }
-                ProcessedStatProp::mk_fol(id.as_str(), &formula)
             }
-        };
-        processed_props.push(stat_prop_processed)
+        }
     }
 
     Ok(processed_props)

--- a/src-tauri/src/algorithms/eval_static/processed_props.rs
+++ b/src-tauri/src/algorithms/eval_static/processed_props.rs
@@ -37,6 +37,8 @@ impl ProcessedStatProp {
 /// Since some function symbols of the sketch were unused (in any update functions) and
 /// filtered out when creating the BN, we must also get rid of any static properties referencing
 /// these symbols. Note that removing properties of unused functions has no effect on the results.
+///
+/// TODO: Not sure how to handle generic FOL properties referencing pruned symbols.
 pub fn process_static_props(
     sketch: &Sketch,
     bn: &BooleanNetwork,

--- a/src-tauri/src/bin/run_inference.rs
+++ b/src-tauri/src/bin/run_inference.rs
@@ -14,7 +14,7 @@ use std::sync::mpsc::{Receiver, Sender};
 #[derive(Parser)]
 #[clap(
     author = "Ondřej Huvar",
-    about = "Run the inference of BNs from predefined sketch."
+    about = "Run Boolean network inference using provided BN sketch as input."
 )]
 struct Arguments {
     /// Path to a file with a model in aeon sketch format.

--- a/src-tauri/src/inference/_test_inference/_test_static.rs
+++ b/src-tauri/src/inference/_test_inference/_test_static.rs
@@ -35,19 +35,19 @@ fn inference_template_monotonicity() {
     let sketch = load_test_model();
     let var_d = sketch.model.get_var_id("D").unwrap();
     let id = "d_d_is_activation";
-    let property = mk_monotonicity_prop(&var_d, &var_d, Monotonicity::Activation);
+    let property = mk_reg_monotonicity_prop(&var_d, &var_d, Monotonicity::Activation);
     assert_eq!(add_stat_prop_and_infer(sketch, property, id), 16);
 
     let sketch = load_test_model();
     let var_d = sketch.model.get_var_id("D").unwrap();
     let id = "d_d_is_inhibition";
-    let property = mk_monotonicity_prop(&var_d, &var_d, Monotonicity::Inhibition);
+    let property = mk_reg_monotonicity_prop(&var_d, &var_d, Monotonicity::Inhibition);
     assert_eq!(add_stat_prop_and_infer(sketch, property, id), 16);
 
     let sketch = load_test_model();
     let var_d = sketch.model.get_var_id("D").unwrap();
     let id = "d_d_is_dual";
-    let property = mk_monotonicity_prop(&var_d, &var_d, Monotonicity::Dual);
+    let property = mk_reg_monotonicity_prop(&var_d, &var_d, Monotonicity::Dual);
     assert_eq!(add_stat_prop_and_infer(sketch, property, id), 0);
 }
 
@@ -74,13 +74,13 @@ fn inference_template_essentiality() {
     let var_c = sketch.model.get_var_id("C").unwrap();
     let var_a = sketch.model.get_var_id("A").unwrap();
     let id = "c_a_is_essential";
-    let property = mk_essentiality_prop(&var_c, &var_a, Essentiality::True);
+    let property = mk_reg_essentiality_prop(&var_c, &var_a, Essentiality::True);
     assert_eq!(add_stat_prop_and_infer(sketch, property, id), 16);
 
     let sketch = load_test_model();
     let var_c = sketch.model.get_var_id("C").unwrap();
     let var_a = sketch.model.get_var_id("A").unwrap();
     let id = "c_a_not_essential";
-    let property = mk_essentiality_prop(&var_c, &var_a, Essentiality::False);
+    let property = mk_reg_essentiality_prop(&var_c, &var_a, Essentiality::False);
     assert_eq!(add_stat_prop_and_infer(sketch, property, id), 16);
 }

--- a/src-tauri/src/inference/inference_solver.rs
+++ b/src-tauri/src/inference/inference_solver.rs
@@ -548,11 +548,12 @@ impl InferenceSolver {
         let mut finished_early = false;
 
         /* >> STEP 1: process basic components of the sketch to be used */
-        // extract the BN (including input simplifications, like filtering out unused function symbols)
+        // Extract the BN (including input simplifications, like filtering out unused function symbols)
         let bn = Self::extract_bn(&sketch)?;
-        // pre-process static properties into a version more suitable for the computation
+        // Pre-process static properties into a version more suitable for the computation
+        // We also have to remove all properties for unused function symbols pruned in previous line
         let static_props = process_static_props(&sketch, &bn)?;
-        // pre-process dynamic properties into a version more suitable for the computation
+        // Pre-process dynamic properties into a version more suitable for the computation
         let dynamic_props = process_dynamic_props(&sketch)?;
 
         self.bn = Some(bn);

--- a/src-tauri/src/sketchbook/_sketch/_impl_consistency.rs
+++ b/src-tauri/src/sketchbook/_sketch/_impl_consistency.rs
@@ -61,9 +61,20 @@ impl Sketch {
         let mut message = String::new();
         message += "MODEL:\n";
 
+        // check model is not empty
         if self.model.num_vars() == 0 {
             consitent = false;
             message += "> ISSUE: There must be at least one variable.\n";
+        }
+
+        // Check there are no function symbols that would be completely unused in any expression.
+        // Note that we automatically prune the unused symbols before the inference anyway, so this
+        // is just to inform the user. Unused symbols can cause issues only if used in properties.
+        let unused_fn_symbols = self.model.find_unused_uninterpreted_fns();
+        for fn_symbol in unused_fn_symbols {
+            consitent = false;
+            let issue = format!("> ISSUE: Function `{fn_symbol}` is unused (not referenced in any function expression). Remove it.\n");
+            message += &issue;
         }
 
         // TODO: in future, we can also add a check if update fn expressions match regulation properties,

--- a/src-tauri/src/sketchbook/_sketch/_impl_import.rs
+++ b/src-tauri/src/sketchbook/_sketch/_impl_import.rs
@@ -145,14 +145,14 @@ impl Sketch {
             let target_var = reg.get_target();
 
             if reg.get_essentiality() != &Essentiality::Unknown {
-                let prop_id = StatProperty::get_essentiality_prop_id(input_var, target_var);
-                let prop = mk_essentiality_prop(input_var, target_var, *reg.get_essentiality());
+                let prop_id = StatProperty::get_reg_essentiality_prop_id(input_var, target_var);
+                let prop = mk_reg_essentiality_prop(input_var, target_var, *reg.get_essentiality());
                 sketch.properties.add_static(prop_id, prop)?;
             }
 
             if reg.get_sign() != &Monotonicity::Unknown {
-                let prop_id = StatProperty::get_monotonicity_prop_id(input_var, target_var);
-                let prop = mk_monotonicity_prop(input_var, target_var, *reg.get_sign());
+                let prop_id = StatProperty::get_reg_monotonicity_prop_id(input_var, target_var);
+                let prop = mk_reg_monotonicity_prop(input_var, target_var, *reg.get_sign());
                 sketch.properties.add_static(prop_id, prop)?;
             }
         }

--- a/src-tauri/src/sketchbook/_sketch/_impl_session_state.rs
+++ b/src-tauri/src/sketchbook/_sketch/_impl_session_state.rs
@@ -89,9 +89,10 @@ impl SessionState for Sketch {
             file.read_to_string(&mut contents)?;
 
             // parse the SketchData, modify the sketch
-            let sketch_data = SketchData::from_json_str(&contents)?;
-            self.modify_from_sketch_data(&sketch_data)?;
+            let new_sketch = Sketch::from_custom_json(&contents)?;
+            self.modify_from_sketch(&new_sketch);
 
+            let sketch_data = SketchData::new_from_sketch(self);
             let state_change = make_state_change(&["sketch", "set_all"], &sketch_data);
             // this is probably one of the real irreversible changes
             Ok(Consumed::Irreversible {

--- a/src-tauri/src/sketchbook/_tests_events/_model.rs
+++ b/src-tauri/src/sketchbook/_tests_events/_model.rs
@@ -269,25 +269,25 @@ fn test_change_fn_arg_monotonicity_essentiality() {
     let model_orig = model.clone();
 
     // test event for changing uninterpreted fn's monotonicity
-    let at_path = ["uninterpreted_fn", f.as_str(), "set_monotonicity"];
+    let at_path = ["uninterpreted_fn", f.as_str(), "set_monotonicity_raw"];
     let change_data = ChangeArgMonotoneData::new(1, Monotonicity::Dual).to_json_str();
     let event = mk_model_event(&at_path, Some(&change_data));
     let result = model.perform_event(&event, &at_path).unwrap();
     // check if the argument's monotonicity changed correctly, and test reverse event
     let uninterpreted_fn = model.get_uninterpreted_fn(&f).unwrap();
     assert_eq!(uninterpreted_fn.get_monotonic(1), &Monotonicity::Dual);
-    let reverse_at_path = ["uninterpreted_fn", f.as_str(), "set_monotonicity"];
+    let reverse_at_path = ["uninterpreted_fn", f.as_str(), "set_monotonicity_raw"];
     check_reverse(&mut model, &model_orig, result, &reverse_at_path);
 
     // test event for changing uninterpreted fn's expression
-    let at_path = ["uninterpreted_fn", f.as_str(), "set_essentiality"];
+    let at_path = ["uninterpreted_fn", f.as_str(), "set_essentiality_raw"];
     let change_data = ChangeArgEssentialData::new(1, Essentiality::True).to_json_str();
     let event = mk_model_event(&at_path, Some(&change_data));
     let result = model.perform_event(&event, &at_path).unwrap();
     // check if the argument's essentiality changed correctly, and test reverse event
     let uninterpreted_fn = model.get_uninterpreted_fn(&f).unwrap();
     assert_eq!(uninterpreted_fn.get_essential(1), &Essentiality::True);
-    let reverse_at_path = ["uninterpreted_fn", f.as_str(), "set_essentiality"];
+    let reverse_at_path = ["uninterpreted_fn", f.as_str(), "set_essentiality_raw"];
     check_reverse(&mut model, &model_orig, result, &reverse_at_path);
 }
 

--- a/src-tauri/src/sketchbook/model/_function_tree.rs
+++ b/src-tauri/src/sketchbook/model/_function_tree.rs
@@ -2,7 +2,7 @@ use crate::sketchbook::ids::{UninterpretedFnId, VarId};
 use crate::sketchbook::model::{BinaryOp, ModelState, UninterpretedFn};
 use biodivine_lib_param_bn::{BooleanNetwork, FnUpdate};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 /// Syntactic tree of a partially defined Boolean function.
 /// This might specify an update function, or a partially defined uninterpreted fn.
@@ -10,14 +10,18 @@ use std::collections::HashSet;
 pub enum FnTree {
     /// A true/false constant.
     Const(bool),
-    /// References a network variable.
+    /// A network variable. The ID corresponds to some variable in the BN.
     Var(VarId),
-    /// References a "placeholder network variable" that corresponds to an argument of an uninterpreted fn.
+    /// A "placeholder variable" that corresponds to a formal argument of an
+    /// uninterpreted fn. This way we can build expressions for uninterpreted functions
+    /// using formal arguments, independent from the actual arguments they are applied
+    /// to within update functions.
     PlaceholderVar(VarId),
-    /// References a network parameter (uninterpreted function).
-    /// The variable list are the arguments of the function invocation.
+    /// A function symbol (also called uninterpreted function or BN parameter) applied
+    /// to a list of arguments. The ID corresponds to some uninterpreted fn in the BN.
+    /// The list are the arguments (parsed expressions) the function is called with.
     UninterpretedFn(UninterpretedFnId, Vec<FnTree>),
-    /// Negation.
+    /// Negation operation.
     Not(Box<FnTree>),
     /// Binary Boolean operation.
     Binary(BinaryOp, Box<FnTree>, Box<FnTree>),
@@ -35,11 +39,12 @@ fn parse_update_fn_wrapper(
 }
 
 impl FnTree {
-    /// Try to parse an update function from a string, taking IDs from the provided `ModelState`.
+    /// Try to parse a function expression, using the IDs from the provided `ModelState`.
     ///
-    /// `is_uninterpreted` specifies whether the expression represents an uninterpreted function,
-    /// or an update function. This must be distinguished as update functions can contain network
-    /// variables, but uninterpreted functions only utilize "unnamed" variables `var0`, `var1`, ...
+    /// Arg `is_uninterpreted` specifies whether the expression represents an uninterpreted
+    /// function, or an update function. This must be distinguished as update functions  
+    /// expressions reference network variables directly, but uninterpreted functions only
+    /// utilize "unnamed" placeholder variables `var0`, `var1`, ... as their formal arguments.
     pub fn try_from_str(
         expression: &str,
         model: &ModelState,
@@ -69,8 +74,8 @@ impl FnTree {
         fn_update.to_string(&bn_context)
     }
 
-    /// Obtain the `FnTree` from a similar `FnUpdate` object of the [biodivine_lib_param_bn] library.
-    /// The provided model gives context for variable and parameter IDs.
+    /// Obtain the `FnTree` from a similar `FnUpdate` object of the [biodivine_lib_param_bn]
+    /// library. The provided model gives context for variable and parameter IDs.
     fn from_fn_update(
         fn_update: FnUpdate,
         model: &ModelState,
@@ -85,8 +90,16 @@ impl FnTree {
         }
     }
 
-    /// Recursively obtain the `FnTree` from a similar `FnUpdate` object of the [biodivine_lib_param_bn] library.
-    /// The provided model and BN give context for variable and parameter IDs.
+    /// Recursively obtain the `FnTree` from a similar `FnUpdate` object of the [biodivine_lib_param_bn]
+    /// library. The provided model and BN are used to get context for variable and parameter IDs.
+    ///
+    /// Argument `is_uninterpreted` is used to determine whether the result should be an uninterpreted
+    /// or an update function's expression. This determines whether the variables should be translated
+    /// as standard BN variables (for update fn) or placeholder variables (for uninterpreted fn).
+    /// Moreover, if this should be an uninterpreted function, it must not reference its own ID
+    /// to avoid recursive definitions.
+    ///
+    /// BN parameters are translated into uninterpreted functions.
     fn from_fn_update_recursive(
         fn_update: FnUpdate,
         model: &ModelState,
@@ -96,7 +109,9 @@ impl FnTree {
         match fn_update {
             FnUpdate::Const(value) => Ok(FnTree::Const(value)),
             FnUpdate::Var(id) => {
-                // in BN, the var's ID is a number and its name is a string (corresponding to variable ID here)
+                // In the BooleanNetwork, variable IDs are (internal) number indices
+                // More important is a variable's string name which is used in update functions
+                // We thus use the BN variable name as its ID in Sketchbook
                 let var_id_str = bn_context.get_variable_name(id);
                 if is_uninterpreted.is_some() {
                     let var_id = model.get_placeholder_var_id(var_id_str)?;
@@ -127,7 +142,8 @@ impl FnTree {
                 let fn_id_str = bn_context[id].get_name();
                 let fn_id = model.get_uninterpreted_fn_id(fn_id_str)?;
 
-                // disallow recursive definition for uninterpreted fns (using a function symbol in its own expression)
+                // disallow recursive definition for uninterpreted fns (using a function symbol in
+                // its own expression)
                 if let Some(fn_id_def) = is_uninterpreted {
                     if fn_id == *fn_id_def {
                         let msg = format!(
@@ -146,13 +162,19 @@ impl FnTree {
         }
     }
 
-    /// Recursively transform the `FnTree` to a similar `FnUpdate` object of the [biodivine_lib_param_bn] library.
-    /// The provided BN gives context for variable and parameter IDs.
+    /// Recursively transform the `FnTree` to a similar `FnUpdate` object of the
+    /// [biodivine_lib_param_bn] library. The provided BN gives context for variable and
+    /// parameter IDs.
+    ///
+    /// Variables are simply translated into BN variables, and uninterpreted functions into
+    /// PSBN parameters.
     pub(crate) fn to_fn_update_recursive(&self, bn_context: &BooleanNetwork) -> FnUpdate {
         match self {
             FnTree::Const(value) => FnUpdate::Const(*value),
             FnTree::Var(var_id) => {
-                // in BN, the var's ID is a number and its name is a string (corresponding to variable ID here)
+                // In the BooleanNetwork, variable IDs are arbitrary (internal) number indices
+                // More important is a variable's string name which is used in update functions
+                // Sketchbook's variable ID is thus used as BN variable name
                 let bn_var_id = bn_context
                     .as_graph()
                     .find_variable(var_id.as_str())
@@ -193,8 +215,9 @@ impl FnTree {
 
     /// Return a set of all variables that are actually used in this function as arguments.
     ///
-    /// Both valid `network variables` and `placeholder variables` are collected (note that
-    /// these two variants can never happen to be in the same tree at the same time).
+    /// Both valid `network variables` and `placeholder variables` are collected. Note that
+    /// these two variants can never appear in the same tree, since one is used within update
+    /// functions, and the other within uninterpreted functions.
     pub fn collect_variables(&self) -> HashSet<VarId> {
         fn r_arguments(function: &FnTree, args: &mut HashSet<VarId>) {
             match function {
@@ -247,13 +270,15 @@ impl FnTree {
         params
     }
 
-    /// Use this function as a template to create a new one, but substitute a given network
-    /// variable's ID with a new one.
+    /// Create a new copy of this function tree, but substitute all occurances of a given
+    /// network variable's ID with a new one (essentially "renaming" the variable).
     ///
-    /// This can only be used to substitute `network variables` (that appear in update functions),
-    /// not placeholder variables (that appear in uninterpreted functions), since modifying the
-    /// latter does not make that much sense.
-    pub fn substitute_var(&self, old_id: &VarId, new_id: &VarId) -> FnTree {
+    /// This method only considers `network variables` (the variables that appear in update
+    /// functions). It ignores `placeholder variables` (that appear in uninterpreted functions).
+    ///
+    /// See also similar method [FnTree::substitute_var] that substitutes placeholder
+    /// variables with network variables.
+    pub fn change_var_id(&self, old_id: &VarId, new_id: &VarId) -> FnTree {
         match self {
             FnTree::Const(_) => self.clone(),
             FnTree::Var(id) => {
@@ -267,46 +292,148 @@ impl FnTree {
             FnTree::UninterpretedFn(id, args) => {
                 let new_args = args
                     .iter()
-                    .map(|it| it.substitute_var(old_id, new_id))
+                    .map(|it| it.change_var_id(old_id, new_id))
                     .collect::<Vec<_>>();
                 FnTree::UninterpretedFn(id.clone(), new_args)
             }
-            FnTree::Not(inner) => (*inner).substitute_var(old_id, new_id),
+            FnTree::Not(inner) => FnTree::Not(Box::new((*inner).change_var_id(old_id, new_id))),
             FnTree::Binary(op, l, r) => FnTree::Binary(
                 *op,
-                Box::new((*l).substitute_var(old_id, new_id)),
-                Box::new((*r).substitute_var(old_id, new_id)),
+                Box::new((*l).change_var_id(old_id, new_id)),
+                Box::new((*r).change_var_id(old_id, new_id)),
             ),
         }
     }
 
-    /// Use this function as a template to create a new one, but substitute a given uninterpreted
-    /// function's ID with a new one.
-    pub fn substitute_fn_symbol(
-        &self,
-        old_id: &UninterpretedFnId,
-        new_id: &UninterpretedFnId,
-    ) -> FnTree {
+    /// Create a new copy of this function tree, but substitute all occurances of given
+    /// uninterpreted function's ID with a new one (essentially "renaming" the function).
+    ///
+    /// You must ensure the functions should have the same amount of arguments and this
+    /// change will be consistent with the rest of the sketch. This is just a syntactic
+    /// substitution.
+    pub fn change_fn_id(&self, old_id: &UninterpretedFnId, new_id: &UninterpretedFnId) -> FnTree {
         match self {
             FnTree::Const(_) => self.clone(),
             FnTree::Var(_) => self.clone(),
             FnTree::PlaceholderVar(_) => self.clone(),
             FnTree::UninterpretedFn(id, args) => {
-                let new_args = args
+                let transformed_args = args
                     .iter()
-                    .map(|it| it.substitute_fn_symbol(old_id, new_id))
+                    .map(|it| it.change_fn_id(old_id, new_id))
                     .collect::<Vec<_>>();
                 if old_id == id {
-                    FnTree::UninterpretedFn(new_id.clone(), new_args)
+                    FnTree::UninterpretedFn(new_id.clone(), transformed_args)
                 } else {
-                    FnTree::UninterpretedFn(id.clone(), new_args)
+                    FnTree::UninterpretedFn(id.clone(), transformed_args)
                 }
             }
-            FnTree::Not(inner) => (*inner).substitute_fn_symbol(old_id, new_id),
+            FnTree::Not(inner) => FnTree::Not(Box::new((*inner).change_fn_id(old_id, new_id))),
             FnTree::Binary(op, l, r) => FnTree::Binary(
                 *op,
-                Box::new((*l).substitute_fn_symbol(old_id, new_id)),
-                Box::new((*r).substitute_fn_symbol(old_id, new_id)),
+                Box::new((*l).change_fn_id(old_id, new_id)),
+                Box::new((*r).change_fn_id(old_id, new_id)),
+            ),
+        }
+    }
+
+    /// Create a new copy of this function tree, but substitute all placeholder variables
+    /// nodes with `FnTree` subtrees, according to a provided mapping.
+    ///
+    /// You must make sure the mapping covers all placeholder variables present in the expression.
+    pub fn substitute_all_placeholders(
+        &self,
+        subst_mapping: &HashMap<VarId, FnTree>,
+    ) -> Result<FnTree, String> {
+        let res = match self {
+            FnTree::Const(_) => self.clone(),
+            FnTree::Var(_) => self.clone(),
+            FnTree::PlaceholderVar(id) => {
+                if let Some(new_sub_expression) = subst_mapping.get(id) {
+                    new_sub_expression.clone()
+                } else {
+                    return Err(format!(
+                        "Variable {id} is not present in the substitution mapping."
+                    ));
+                }
+            }
+            FnTree::UninterpretedFn(id, args) => {
+                let new_args = args
+                    .iter()
+                    .map(|it| it.substitute_all_placeholders(subst_mapping))
+                    .collect::<Result<Vec<_>, String>>()?;
+                FnTree::UninterpretedFn(id.clone(), new_args)
+            }
+            FnTree::Not(inner) => FnTree::Not(Box::new(
+                (*inner).substitute_all_placeholders(subst_mapping)?,
+            )),
+            FnTree::Binary(op, l, r) => FnTree::Binary(
+                *op,
+                Box::new((*l).substitute_all_placeholders(subst_mapping)?),
+                Box::new((*r).substitute_all_placeholders(subst_mapping)?),
+            ),
+        };
+        Ok(res)
+    }
+
+    /// Create a new copy of this function tree, but substitute all occurances of given
+    /// uninterpreted function with its (transformed) expression.
+    ///
+    /// Before replacing the function symbol with its expression, the expression will be
+    /// tranformed. The formal parameters of the function will be substituted with the actual
+    /// parameters to which the function is applied.
+    ///
+    /// For example, if this is tree for function `A & fn_1(B, C)`, and we have the following
+    /// expression for fn_1: `fn_1(var1, var2) = var1 | var2`, then this will result in a tree
+    /// for `A & (B | C)`.
+    pub fn substitute_fn_symbol_with_expression(
+        &self,
+        fn_id: &UninterpretedFnId,
+        fn_expression: &FnTree,
+    ) -> FnTree {
+        // TODO: we must substitute the symbol (in update fn tree) with the expression
+
+        match self {
+            FnTree::Const(_) => self.clone(),
+            FnTree::Var(_) => self.clone(),
+            FnTree::PlaceholderVar(_) => self.clone(),
+            FnTree::UninterpretedFn(id, args) => {
+                let transformed_args = args
+                    .iter()
+                    .map(|it| it.substitute_fn_symbol_with_expression(fn_id, fn_expression))
+                    .collect::<Vec<_>>();
+
+                if fn_id == id {
+                    let mut transformed_fn_expression = fn_expression.clone();
+
+                    // TODO: 1) compute the mapping of formal -> actual function arguments (placeholder_var -> fn_tree)
+                    let formal_to_actual_arg_map = transformed_args
+                        .into_iter()
+                        .enumerate()
+                        .map(|(i, arg_expression)| {
+                            (
+                                VarId::new(format!("var{i}").as_str()).unwrap(),
+                                arg_expression,
+                            )
+                        })
+                        .collect::<HashMap<VarId, FnTree>>();
+
+                    // TODO: 2) substitute placeholder variables in uninterpreted fn expression using the mapping
+                    transformed_fn_expression = transformed_fn_expression
+                        .substitute_all_placeholders(&formal_to_actual_arg_map)
+                        .unwrap();
+                    // TODO: 3) substitute the function symbol here with its transformed expression
+                    transformed_fn_expression
+                } else {
+                    FnTree::UninterpretedFn(id.clone(), transformed_args)
+                }
+            }
+            FnTree::Not(inner) => FnTree::Not(Box::new(
+                (*inner).substitute_fn_symbol_with_expression(fn_id, fn_expression),
+            )),
+            FnTree::Binary(op, l, r) => FnTree::Binary(
+                *op,
+                Box::new((*l).substitute_fn_symbol_with_expression(fn_id, fn_expression)),
+                Box::new((*r).substitute_fn_symbol_with_expression(fn_id, fn_expression)),
             ),
         }
     }
@@ -428,11 +555,11 @@ mod tests {
         let fn_tree = FnTree::try_from_str("a & f(a)", &model, None).unwrap();
 
         // variable substitution
-        let modified_tree = fn_tree.substitute_var(&a, &b);
+        let modified_tree = fn_tree.change_var_id(&a, &b);
         assert_eq!(modified_tree.to_string(&model, None), "b & f(b)");
 
         // function symbol substitution
-        let modified_tree = fn_tree.substitute_fn_symbol(&f, &g);
+        let modified_tree = fn_tree.change_fn_id(&f, &g);
         assert_eq!(modified_tree.to_string(&model, None), "a & g(a)");
     }
 

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_convert_bn.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_convert_bn.rs
@@ -6,15 +6,18 @@ impl ModelState {
     /// Internal function to convert the `ModelState` into a variant of `BooleanNetwork` with
     /// specified information to be included.
     ///
-    /// By default, all variables and regulations are included. You can choose the following:
-    /// - `regulation_types`: include types of regulations
-    /// - `parameters`: include all parameters for uninterpreted functions
-    /// - `update_fns`: include all update functions
-    /// - `extra_vars`: additional extra variables (with no update fns, no regulations)
+    /// By default, only "influence graph info" is included: variables and (plain) regulations.
+    /// You can further specify to include the following:
+    /// - `regulation_types`: include properties of regulations (monotonicity, essentiality)
+    /// - `parameters`: include uninterpreted functions as network parameters
+    /// - `update_fns`: include update function expressions
+    /// - `extra_vars`: add additional extra variables (with no update fns, no regulations)
     ///
     /// It is up to you to make the selection reasonable (e.g., when including update functions
     /// that contain parameters, you must also include parameters, and so on...).
-    fn to_bn_with_options(
+    /// Rather use one of the provided wrappers. For instance, you can get the full PSBN with
+    /// all info using [Self::to_bn].
+    fn to_bn_internal(
         &self,
         regulation_types: bool,
         parameters: bool,
@@ -38,8 +41,23 @@ impl ModelState {
 
         if update_fns {
             for (var_id, update_fn) in self.update_fns.iter() {
-                if !update_fn.is_unspecified() {
-                    bn.add_string_update_function(var_id.as_str(), update_fn.get_fn_expression())?;
+                if !update_fn.has_empty_expression() {
+                    let mut transformed_update_fn_tree = update_fn.get_fn_tree().clone().unwrap();
+                    // TODO: check if this fn contains any function symbols that have their expressions specified
+                    let fn_symbols_used = update_fn.collect_fn_symbols();
+                    for fn_id in fn_symbols_used {
+                        let uninterpreted_fn = self.get_uninterpreted_fn(&fn_id)?;
+                        if let Some(fn_expression_tree) = uninterpreted_fn.get_fn_tree() {
+                            // TODO: if there is an expression, we must substitute the symbol (in update fn tree) with the expression
+                            // all the magical transformations happen inside this method
+                            transformed_update_fn_tree = transformed_update_fn_tree
+                                .substitute_fn_symbol_with_expression(&fn_id, fn_expression_tree);
+                        }
+                    }
+
+                    // TODO: add (potentionally transformed) update function
+                    let transformed_expression = transformed_update_fn_tree.to_string(self, None);
+                    bn.add_string_update_function(var_id.as_str(), &transformed_expression)?;
                 }
             }
         }
@@ -51,7 +69,7 @@ impl ModelState {
     /// and does not cover any parameters.
     pub fn to_empty_bn(&self) -> BooleanNetwork {
         // this is a safe combination that cannot result in errors
-        self.to_bn_with_options(true, false, false, None).unwrap()
+        self.to_bn_internal(true, false, false, None).unwrap()
     }
 
     /// Convert the `ModelState` into the corresponding "default" `BooleanNetwork` object with added
@@ -59,16 +77,19 @@ impl ModelState {
     /// The resulting BN covers the variables, parameters, and regulations, but it has empty update functions.
     pub fn to_empty_bn_with_params(&self) -> BooleanNetwork {
         // this is a safe combination that cannot result in errors
-        self.to_bn_with_options(true, true, false, None).unwrap()
+        self.to_bn_internal(true, true, false, None).unwrap()
     }
 
-    /// Generate a `BooleanNetwork` with a only given number of "placeholder" (fake) variables.
+    /// Generate a `BooleanNetwork` containing only "placeholder" (fake) variables.
     /// These variables will be named `var0`, `var1`, ...
     ///
     /// The resulting BN will normally contain all uninterpreted functions (parameters) of this model.
     /// There will be no regulations, and update functions will be empty.
     ///
-    /// This is useful for parsing `FnUpdate` objects describing syntactic trees of uninterpreted functions.
+    /// We need this for parsing expressions of uninterpreted functions. Uninterpreted function
+    /// expression contain these placeholder variables as their formal arguments. We thus need a
+    /// "fake" BN to contain these variables as a context when internally creating `FnUpdate` instances
+    /// describing the syntactic tree.
     pub fn to_fake_bn_with_params(&self, num_variables: usize) -> BooleanNetwork {
         // construct a bn with fake variables
         let fake_vars = (0..num_variables).map(|i| format!("var{i}")).collect();
@@ -91,7 +112,7 @@ impl ModelState {
     /// various regulation types or details of uninterpreted functions) -- these will be lost during the conversion.
     pub fn to_bn(&self) -> BooleanNetwork {
         // this is a safe combination that cannot result in errors
-        self.to_bn_with_options(true, true, true, None).unwrap()
+        self.to_bn_internal(true, true, true, None).unwrap()
     }
 
     /// Convert the `ModelState` into the corresponding `BooleanNetwork` object (that will contain all of the
@@ -105,8 +126,7 @@ impl ModelState {
     /// regulations.
     pub fn to_bn_with_plain_regulations(&self, extra_vars: Option<Vec<String>>) -> BooleanNetwork {
         // this is a safe combination that cannot result in errors
-        self.to_bn_with_options(false, true, true, extra_vars)
-            .unwrap()
+        self.to_bn_internal(false, true, true, extra_vars).unwrap()
     }
 }
 
@@ -147,8 +167,13 @@ impl ModelState {
 mod tests {
     use crate::sketchbook::model::ModelState;
 
-    /// Prepare a test model containing all the different components.
-    pub(super) fn prepare_test_model_full() -> ModelState {
+    /// Prepare a test model used across the tests here.
+    /// The model is containing all the different components:
+    /// - variables `a`, `b`
+    /// - regulations `a -> b`, `b -> a`, `a -| a`
+    /// - function symbol `f` of arity 2
+    /// - `a` has update `(b & !a) | f(a, b)`, `b` has empty update
+    fn prepare_test_model_full() -> ModelState {
         let mut model = ModelState::new_from_vars(vec![("a", "a"), ("b", "b")]).unwrap();
         let var_a = model.get_var_id("a").unwrap();
         model
@@ -157,7 +182,10 @@ mod tests {
         model
             .add_empty_uninterpreted_fn_by_str("f", "f", 2)
             .unwrap();
-        model.set_update_fn(&var_a, "b & !a").unwrap();
+        model.set_update_fn(&var_a, "(b & !a) | f(a, b)").unwrap();
+        model
+            .set_uninterpreted_fn_expression_by_str("f", "var0 => var1")
+            .unwrap();
         model
     }
 
@@ -180,21 +208,29 @@ mod tests {
         assert!(bn.find_parameter("f").is_some());
     }
 
+    /// Test whether conversion to BN correctly propagates expressions of uninterpreted
+    /// functions into update functions.
+    ///
+    /// Update fn for `a` is `(b & !a) | f(a, b)`, which contains uninterpreted fn `f`.
+    /// We set expression for `f(var0, var1)` to `var0 => var1`. Therefore, the update
+    /// function should be transformed into `(b & !a) | (a => b)`
     #[test]
-    fn test_to_bn_and_back() {
-        let model = prepare_test_model_full();
+    fn test_to_bn_with_propagated_expressions() {
+        let mut model = prepare_test_model_full();
+        model
+            .set_uninterpreted_fn_expression_by_str("f", "var0 => var1")
+            .unwrap();
+
         let bn = model.to_bn();
         let var_a = bn.as_graph().find_variable("a").unwrap();
         let var_b = bn.as_graph().find_variable("b").unwrap();
-        let model_var_a = model.get_var_id("a").unwrap();
-        let update_var_a = model.get_update_fn(&model_var_a).unwrap().to_fn_update(&bn);
-        assert_eq!(bn.get_update_function(var_a), &update_var_a);
+        let update_var_a = bn
+            .get_update_function(var_a)
+            .as_ref()
+            .unwrap()
+            .to_string(&bn);
+        assert_eq!(update_var_a, "(b & !a) | (a => b)");
         assert_eq!(bn.get_update_function(var_b), &None);
-
-        // the conversion back works only if IDs and names (for variables, functions) match (which
-        // is out case)
-        let model_converted = ModelState::from_bn(&bn).unwrap();
-        assert_eq!(model, model_converted);
     }
 
     #[test]

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_editing.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_editing.rs
@@ -1018,7 +1018,7 @@ impl ModelState {
             fn_symbols.extend(tmp_fn_symbols);
         }
         if fn_symbols.contains(fn_id) {
-            Err(format!("Cannot remove fn symbol `{fn_id}`, it is still contained in an update/uninterpreted function."))
+            Err(format!("Cannot alter fn symbol `{fn_id}`, it is currently used in some update/uninterpreted function."))
         } else {
             Ok(())
         }

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_editing.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_editing.rs
@@ -478,6 +478,10 @@ impl ModelState {
     /// In order to change arity of a function symbol, it must not currently be used in any
     /// update/uninterpreted function's expression (because in expressions, it is applied on a
     /// fixed number of arguments).
+    ///
+    /// If arity is made larger, new arguments (without any monotonicity/essentiality constraints
+    /// are added. If arity is made smaller, then appropriate number of existing arguments is
+    /// dropped, starting from the last. These arguments must not be used in function's expression.
     pub fn set_uninterpreted_fn_arity(
         &mut self,
         fn_id: &UninterpretedFnId,

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_editing.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_editing.rs
@@ -476,7 +476,7 @@ impl ModelState {
     /// Set arity of an uninterpreted fn given by id `fn_id`.
     ///
     /// In order to change arity of a function symbol, it must not currently be used in any
-    /// update/uninterpreted function's expression (because in expressions, it is used on a
+    /// update/uninterpreted function's expression (because in expressions, it is applied on a
     /// fixed number of arguments).
     pub fn set_uninterpreted_fn_arity(
         &mut self,
@@ -499,22 +499,6 @@ impl ModelState {
     ) -> Result<(), String> {
         let fn_id = UninterpretedFnId::new(id)?;
         self.set_uninterpreted_fn_arity(&fn_id, arity)
-    }
-
-    /// Increment the arity of an uninterpreted fn given by id `fn_id`. Basically adds a defualt
-    /// argument (with unknown monotonicity/essentiality) at the end of the function's arg list.
-    pub fn increment_fn_arity(&mut self, fn_id: &UninterpretedFnId) -> Result<(), String> {
-        self.assert_valid_uninterpreted_fn(fn_id)?;
-        let uninterpreted_fn = self.uninterpreted_fns.get(fn_id).unwrap();
-        self.set_uninterpreted_fn_arity(fn_id, uninterpreted_fn.get_arity() + 1)
-    }
-
-    /// Decrement the arity of an uninterpreted fn given by id `fn_id`. Basically drops the last
-    /// argument of the function. The last argument must not be used in function's expression.
-    pub fn decrement_fn_arity(&mut self, fn_id: &UninterpretedFnId) -> Result<(), String> {
-        self.assert_valid_uninterpreted_fn(fn_id)?;
-        let uninterpreted_fn = self.uninterpreted_fns.get(fn_id).unwrap();
-        self.set_uninterpreted_fn_arity(fn_id, uninterpreted_fn.get_arity() - 1)
     }
 
     /// Set expression of an uninterpreted fn given by id `fn_id`.

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_observing.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_observing.rs
@@ -315,7 +315,7 @@ impl ModelState {
     /// Returned list contains string ID of each such variable
     pub fn get_vars_with_empty_update(&self) -> Vec<&str> {
         self.update_fns()
-            .filter(|(_, update_fn)| update_fn.is_unspecified())
+            .filter(|(_, update_fn)| update_fn.has_empty_expression())
             .map(|(var_id, _)| var_id.as_str())
             .collect()
     }

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_observing.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_observing.rs
@@ -6,6 +6,7 @@ use crate::sketchbook::model::{
     UninterpretedFnIterator, UpdateFn, UpdateFnIterator, Variable, VariableIterator,
 };
 
+use std::collections::HashSet;
 use std::str::FromStr;
 
 /// Id (and also name) of the initial default layout.
@@ -393,5 +394,28 @@ impl ModelState {
     /// Static fn to get name of the default layout (same for all `ModelStates`).
     pub fn get_default_layout_name() -> &'static str {
         DEFAULT_LAYOUT_ID
+    }
+
+    /// Compute all uninterpreted functions that are unused (not present in any update
+    /// function expression or any uninterpreted function expressions).
+    ///
+    /// TODO: This does not take into account more complex type of function symbols that are
+    /// used, but only inside of expressions of other function symbols that are unused.
+    pub fn find_unused_uninterpreted_fns(&self) -> HashSet<UninterpretedFnId> {
+        let mut unused_functions: HashSet<UninterpretedFnId> =
+            self.uninterpreted_fns.keys().cloned().collect();
+        for (_, update_fn) in self.update_fns() {
+            unused_functions = unused_functions
+                .difference(&update_fn.collect_fn_symbols())
+                .cloned()
+                .collect();
+        }
+        for (_, uninterpreted_fn) in self.uninterpreted_fns() {
+            unused_functions = unused_functions
+                .difference(&uninterpreted_fn.collect_fn_symbols())
+                .cloned()
+                .collect();
+        }
+        unused_functions
     }
 }

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_regulations.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_regulations.rs
@@ -15,19 +15,19 @@ use crate::sketchbook::JsonSerde;
 
 // add new regulation, and also propagate changes into static properties
 const ADD_REGULATION_PATH: &str = "add";
-// add new regulation (without additional changes)
+// add new regulation (without additional changes to static properties)
 const ADD_RAW_REGULATION_PATH: &str = "add_raw";
 // remove regulation, and also propagate changes into static properties
 const REMOVE_REGULATION_PATH: &str = "remove";
-// remove regulation (without additional changes)
+// remove regulation (without additional changes to static properties)
 const REMOVE_RAW_REGULATION_PATH: &str = "remove_raw";
 // set regulation's sign, and also propagate changes into static properties
 const SET_SIGN_PATH: &str = "set_sign";
-// set regulation's sign (without additional changes)
+// set regulation's sign (without additional changes to static properties)
 const SET_SIGN_RAW_PATH: &str = "set_sign_raw";
 // set regulation's essentiality, and also propagate changes into static properties
 const SET_ESSENTIALITY_PATH: &str = "set_essentiality";
-// set regulation's essentiality (without additional changes)
+// set regulation's essentiality (without additional changes to static properties)
 const SET_ESSENTIALITY_RAW_PATH: &str = "set_essentiality_raw";
 
 /// Implementation for events related to `regulations` of the model.

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_regulations.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_regulations.rs
@@ -78,15 +78,15 @@ impl ModelState {
         // events of adding the corresponding properties for monotonicity/essentiality in case it
         // is not unknown variant
         if reg_data.essential != Essentiality::Unknown {
-            let prop_id = StatProperty::get_essentiality_prop_id(&input_var, &target_var);
-            let prop = mk_essentiality_prop(&input_var, &target_var, reg_data.essential);
+            let prop_id = StatProperty::get_reg_essentiality_prop_id(&input_var, &target_var);
+            let prop = mk_reg_essentiality_prop(&input_var, &target_var, reg_data.essential);
             let prop_payload = StatPropertyData::from_property(&prop_id, &prop).to_json_str();
             let prop_event = mk_stat_prop_event(&["add"], Some(&prop_payload));
             event_list.push(prop_event);
         }
         if reg_data.sign != Monotonicity::Unknown {
-            let prop_id = StatProperty::get_monotonicity_prop_id(&input_var, &target_var);
-            let prop = mk_monotonicity_prop(&input_var, &target_var, reg_data.sign);
+            let prop_id = StatProperty::get_reg_monotonicity_prop_id(&input_var, &target_var);
+            let prop = mk_reg_monotonicity_prop(&input_var, &target_var, reg_data.sign);
             let prop_payload = StatPropertyData::from_property(&prop_id, &prop).to_json_str();
             let prop_event = mk_stat_prop_event(&["add"], Some(&prop_payload));
             event_list.push(prop_event);
@@ -159,13 +159,13 @@ impl ModelState {
             // case it is not unknown variant
             if *original_reg.get_essentiality() != Essentiality::Unknown {
                 // there is at max one essentiality property for a regulation
-                let prop_id = StatProperty::get_essentiality_prop_id(&regulator_id, &target_id);
+                let prop_id = StatProperty::get_reg_essentiality_prop_id(&regulator_id, &target_id);
                 let prop_event = mk_stat_prop_event(&[prop_id.as_str(), "remove"], None);
                 event_list.push(prop_event);
             }
             if *original_reg.get_sign() != Monotonicity::Unknown {
                 // there is at max one monotonicity property for a regulation
-                let prop_id = StatProperty::get_monotonicity_prop_id(&regulator_id, &target_id);
+                let prop_id = StatProperty::get_reg_monotonicity_prop_id(&regulator_id, &target_id);
                 let prop_event = mk_stat_prop_event(&[prop_id.as_str(), "remove"], None);
                 event_list.push(prop_event);
             }
@@ -212,10 +212,10 @@ impl ModelState {
 
             // events of modifying/adding/removing corresponding static property
             // note we have checked that `orig_sign` and `new_sign` are different
-            let prop_id = StatProperty::get_monotonicity_prop_id(&regulator_id, &target_id);
+            let prop_id = StatProperty::get_reg_monotonicity_prop_id(&regulator_id, &target_id);
             if orig_sign == Monotonicity::Unknown {
                 // before there was no static prop, now we have to add it
-                let prop = mk_monotonicity_prop(&regulator_id, &target_id, new_sign);
+                let prop = mk_reg_monotonicity_prop(&regulator_id, &target_id, new_sign);
                 let prop_payload = StatPropertyData::from_property(&prop_id, &prop).to_json_str();
                 let prop_event = mk_stat_prop_event(&["add"], Some(&prop_payload));
                 event_list.push(prop_event);
@@ -225,7 +225,7 @@ impl ModelState {
                 event_list.push(prop_event);
             } else {
                 // there is a static prop, and we just change its sign
-                let prop = mk_monotonicity_prop(&regulator_id, &target_id, new_sign);
+                let prop = mk_reg_monotonicity_prop(&regulator_id, &target_id, new_sign);
                 let prop_payload = StatPropertyData::from_property(&prop_id, &prop).to_json_str();
                 let prop_event =
                     mk_stat_prop_event(&[prop_id.as_str(), "set_content"], Some(&prop_payload));
@@ -281,10 +281,10 @@ impl ModelState {
 
             // events of modifying/adding/removing corresponding static property
             // note we have checked that `orig_essentiality` and `new_essentiality` are different
-            let prop_id = StatProperty::get_essentiality_prop_id(&regulator_id, &target_id);
+            let prop_id = StatProperty::get_reg_essentiality_prop_id(&regulator_id, &target_id);
             if orig_essentiality == Essentiality::Unknown {
                 // before there was no static prop, now we have to add it
-                let prop = mk_essentiality_prop(&regulator_id, &target_id, new_essentiality);
+                let prop = mk_reg_essentiality_prop(&regulator_id, &target_id, new_essentiality);
                 let prop_payload = StatPropertyData::from_property(&prop_id, &prop).to_json_str();
                 let prop_event = mk_stat_prop_event(&["add"], Some(&prop_payload));
                 event_list.push(prop_event);
@@ -294,7 +294,7 @@ impl ModelState {
                 event_list.push(prop_event);
             } else {
                 // there is a static prop, and we just change its essentiality
-                let prop = mk_essentiality_prop(&regulator_id, &target_id, new_essentiality);
+                let prop = mk_reg_essentiality_prop(&regulator_id, &target_id, new_essentiality);
                 let prop_payload = StatPropertyData::from_property(&prop_id, &prop).to_json_str();
                 let prop_event =
                     mk_stat_prop_event(&[prop_id.as_str(), "set_content"], Some(&prop_payload));

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_uninterpreted_fns.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_uninterpreted_fns.rs
@@ -17,16 +17,12 @@ const ADD_FN_PATH: &str = "add";
 const ADD_DEFAULT_FN_PATH: &str = "add_default";
 // remove particular function
 const REMOVE_FN_PATH: &str = "remove";
-// set function's raw data
+// set function's (meta)data (name, annotation)
 const SET_DATA_PATH: &str = "set_data";
 // set function's ID
 const SET_ID_PATH: &str = "set_id";
 // set function's arity
 const SET_ARITY_PATH: &str = "set_arity";
-// increment function's arity
-const INCREMENT_ARITY_PATH: &str = "increment_arity";
-// decrement function's arity
-const DECREMENT_ARITY_PATH: &str = "decrement_arity";
 // set function's expression
 const SET_EXPRESSION_PATH: &str = "set_expression";
 // set monotonicity of function with respect to its argument
@@ -198,32 +194,6 @@ impl ModelState {
             // prepare the reverse event
             let mut reverse_event = event.clone();
             reverse_event.payload = Some(original_arity.to_string());
-            Ok(make_reversible(state_change, event, reverse_event))
-        } else if Self::starts_with(INCREMENT_ARITY_PATH, at_path).is_some() {
-            Self::assert_payload_empty(event, component_name)?;
-
-            // perform the event, prepare the state-change variant (move id from path to payload)
-            self.increment_fn_arity(&fn_id)?;
-            let fn_data = UninterpretedFnData::from_fn(&fn_id, self.get_uninterpreted_fn(&fn_id)?);
-            let state_change =
-                mk_model_state_change(&["uninterpreted_fn", "increment_arity"], &fn_data);
-
-            // prepare the reverse event
-            let reverse_at_path = ["uninterpreted_fn", fn_id.as_str(), "decrement_arity"];
-            let reverse_event = mk_model_event(&reverse_at_path, None);
-            Ok(make_reversible(state_change, event, reverse_event))
-        } else if Self::starts_with(DECREMENT_ARITY_PATH, at_path).is_some() {
-            Self::assert_payload_empty(event, component_name)?;
-
-            // perform the event, prepare the state-change variant (move id from path to payload)
-            self.decrement_fn_arity(&fn_id)?;
-            let fn_data = UninterpretedFnData::from_fn(&fn_id, self.get_uninterpreted_fn(&fn_id)?);
-            let state_change =
-                mk_model_state_change(&["uninterpreted_fn", "decrement_arity"], &fn_data);
-
-            // prepare the reverse event
-            let reverse_at_path = ["uninterpreted_fn", fn_id.as_str(), "increment_arity"];
-            let reverse_event = mk_model_event(&reverse_at_path, None);
             Ok(make_reversible(state_change, event, reverse_event))
         } else if Self::starts_with(SET_EXPRESSION_PATH, at_path).is_some() {
             // get the payload - string for "expression"

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_variables.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_variables.rs
@@ -284,7 +284,7 @@ impl ModelState {
             let var_id_event = mk_model_event(&var_id_event_path, Some(&new_id));
             event_list.push(var_id_event);
 
-            // event for modifying all corresponding static property (we do it via single event)
+            // event for modifying all affected static properties (we do it via a single special event)
             // note we have checked that `var_id` and `new_id` are different
             let id_change_data = ChangeIdData::new(var_id.as_str(), &new_id).to_json_str();
             let prop_event = mk_stat_prop_event(&["set_var_id_everywhere"], Some(&id_change_data));

--- a/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_variables.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/_impl_session_state/_events_variables.rs
@@ -70,7 +70,7 @@ impl ModelState {
     }
 
     /// Perform event of adding a new `variable` component to this `ModelState`.
-    /// This expects that the variable was already defined elsewhere (i.e., its ID and other
+    /// This expects that the variable was already prepared elsewhere (i.e., its ID and other
     /// fields are already known).
     ///
     /// This event will be broken into sub-events (raw addition of the variable, and re-positioning).
@@ -190,16 +190,16 @@ impl ModelState {
             // First step - check that variable can be safely deleted, i.e., it is not contained in
             // any update function's expression.
             // Note this check is performed also later by the manager, we just want to detect this ASAP.
-            if self.is_var_contained_in_updates(&var_id) {
+            if self.is_var_contained_in_expressions(&var_id) {
                 return AeonError::throw(format!(
                     "Cannot remove variable `{var_id}`, it is still contained in some update functions."
                 ));
             }
 
             // To remove a variable, all its regulations must be already removed, and it must be at default position
-            // in each layout. If it is not the case, to ensure that we can undo this operation, we precede the var
-            // removal with a set of events to remove all its regulations, and move its nodes to default positions
-            // (as separate undo-able events).
+            // in each layout. If it is not the case, we must break this event down into smaller ones to ensure that we can
+            // undo this operation later. We prepare a set of events to remove all its regulations, and move the node to
+            // default position, and then remove the variable atomically (all as separate undo-able events).
 
             let targets = self.targets(&var_id)?;
             let regulators = self.regulators(&var_id)?;

--- a/src-tauri/src/sketchbook/model/_model_state/mod.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/mod.rs
@@ -17,11 +17,24 @@ mod _impl_observing;
 /// **(internal)** Implementation of event-based API for the [crate::app::state::SessionState] trait.
 mod _impl_session_state;
 
-/// Object representing the state of the model in the Boolean network editor. The model encompasses
-/// variables, regulations, uninterpreted functions, update functions, and layout information.
+/// Structure representing the state of the "model" part of the sketch. `ModelState`
+/// encompasses information about the regulatory network and the PSBN. Specifically, it
+/// covers:
+/// - set of Boolean variables
+/// - set of regulations between the variables
+/// - set of function symbols (or uninterpreted functions)
+/// - Boolean update functions for each variable
+/// - layout information regarding the regulatory network
 ///
-/// `ModelState` can be observed/edited using its classical Rust API, as well as through the
-/// external events (as it implements the `SessionState` event).
+/// `ModelState` can be observed/edited using its classical Rust API, as well as through
+/// the external events (as it implements the `SessionState` event).
+///
+/// Internally, `ModelState` also tracks so called "placeholder" variables. These are
+/// used to deal with formal arguments of uninterpreted functions. For example, if you
+/// define a function with 5 arguments, five placeholder variables `var0`, `var1`, ... are
+/// tracked. Placeholder variables are shared across functions, so we only keep K of them
+/// where K is the max arity across uninterpreted functions used.
+/// It is just an implementation detail to distinguish them from BN variables.
 #[derive(Clone, Debug, PartialEq)]
 pub struct ModelState {
     variables: HashMap<VarId, Variable>,

--- a/src-tauri/src/sketchbook/model/_model_state/mod.rs
+++ b/src-tauri/src/sketchbook/model/_model_state/mod.rs
@@ -28,13 +28,6 @@ mod _impl_session_state;
 ///
 /// `ModelState` can be observed/edited using its classical Rust API, as well as through
 /// the external events (as it implements the `SessionState` event).
-///
-/// Internally, `ModelState` also tracks so called "placeholder" variables. These are
-/// used to deal with formal arguments of uninterpreted functions. For example, if you
-/// define a function with 5 arguments, five placeholder variables `var0`, `var1`, ... are
-/// tracked. Placeholder variables are shared across functions, so we only keep K of them
-/// where K is the max arity across uninterpreted functions used.
-/// It is just an implementation detail to distinguish them from BN variables.
 #[derive(Clone, Debug, PartialEq)]
 pub struct ModelState {
     variables: HashMap<VarId, Variable>,
@@ -42,7 +35,6 @@ pub struct ModelState {
     update_fns: HashMap<VarId, UpdateFn>,
     uninterpreted_fns: HashMap<UninterpretedFnId, UninterpretedFn>,
     layouts: HashMap<LayoutId, Layout>,
-    placeholder_variables: HashSet<VarId>,
 }
 
 impl Manager for ModelState {}

--- a/src-tauri/src/sketchbook/model/_uninterpreted_fn.rs
+++ b/src-tauri/src/sketchbook/model/_uninterpreted_fn.rs
@@ -2,7 +2,7 @@ use crate::sketchbook::ids::{UninterpretedFnId, VarId};
 use crate::sketchbook::model::{Essentiality, FnArgument, FnTree, ModelState, Monotonicity};
 use crate::sketchbook::utils::assert_name_valid;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 
 /// An uninterpreted function of a partially specified model.
@@ -165,7 +165,7 @@ impl UninterpretedFn {
             self.tree = None;
             self.expression = String::new()
         } else {
-            let syntactic_tree = FnTree::try_from_str(new_expression, model, Some((own_id, self)))?;
+            let syntactic_tree = FnTree::try_from_str(new_expression, model, Some(own_id))?;
             self.expression = syntactic_tree.to_string(model, Some(self.get_arity()));
             self.tree = Some(syntactic_tree);
         }
@@ -225,19 +225,6 @@ impl UninterpretedFn {
             self.expression = new_tree.to_string(context, Some(self.get_arity()));
             self.tree = Some(new_tree);
         }
-    }
-
-    pub fn substitute_all_placeholders(
-        &mut self,
-        substitution_mapping: &HashMap<VarId, FnTree>,
-        context: &ModelState,
-    ) -> Result<(), String> {
-        if let Some(tree) = &self.tree {
-            let new_tree = tree.substitute_all_placeholders(substitution_mapping)?;
-            self.expression = new_tree.to_string(context, Some(self.get_arity()));
-            self.tree = Some(new_tree);
-        }
-        Ok(())
     }
 }
 

--- a/src-tauri/src/sketchbook/model/_update_function.rs
+++ b/src-tauri/src/sketchbook/model/_update_function.rs
@@ -54,8 +54,14 @@ impl UpdateFn {
         &self.expression
     }
 
-    /// Check if the update function is empty (fully unspecified).
-    pub fn is_unspecified(&self) -> bool {
+    /// Get function's syntax tree (or None if expression is empty).
+    pub fn get_fn_tree(&self) -> &Option<FnTree> {
+        &self.tree
+    }
+
+    /// Check if the update function's expression is empty (i.e., if the function
+    /// is fully unspecified).
+    pub fn has_empty_expression(&self) -> bool {
         self.tree.is_none()
     }
 
@@ -101,24 +107,24 @@ impl UpdateFn {
         }
     }
 
-    /// Substitute all occurrences of a given function symbol in the syntactic tree.
-    pub fn substitute_var(&mut self, old_id: &VarId, new_id: &VarId, context: &ModelState) {
+    /// Rename all occurrences of a given variable in the syntactic tree.
+    pub fn change_var_id(&mut self, old_id: &VarId, new_id: &VarId, context: &ModelState) {
         if let Some(tree) = &self.tree {
-            let new_tree = tree.substitute_var(old_id, new_id);
+            let new_tree = tree.change_var_id(old_id, new_id);
             self.expression = new_tree.to_string(context, None);
             self.tree = Some(new_tree);
         }
     }
 
-    /// Substitute all occurrences of a given function symbol in the syntactic tree.
-    pub fn substitute_fn_symbol(
+    /// Rename all occurrences of a given function symbol in the syntactic tree.
+    pub fn change_fn_id(
         &mut self,
         old_id: &UninterpretedFnId,
         new_id: &UninterpretedFnId,
         context: &ModelState,
     ) {
         if let Some(tree) = &self.tree {
-            let new_tree = tree.substitute_fn_symbol(old_id, new_id);
+            let new_tree = tree.change_fn_id(old_id, new_id);
             self.expression = new_tree.to_string(context, None);
             self.tree = Some(new_tree);
         }
@@ -126,25 +132,25 @@ impl UpdateFn {
 
     /// Create update function from another one, substituting all occurrences of a given
     /// function symbol in the syntactic tree. The provided original function object is consumed.
-    pub fn with_substituted_fn_symbol(
+    pub fn with_changed_fn_id(
         mut original_fn: UpdateFn,
         old_id: &UninterpretedFnId,
         new_id: &UninterpretedFnId,
         context: &ModelState,
     ) -> UpdateFn {
-        original_fn.substitute_fn_symbol(old_id, new_id, context);
+        original_fn.change_fn_id(old_id, new_id, context);
         original_fn
     }
 
     /// Create update function from another one, substituting all occurrences of a given
     /// variable in the syntactic tree. The provided original function object is consumed.
-    pub fn with_substituted_var(
+    pub fn with_changed_var_id(
         mut original_fn: UpdateFn,
         old_id: &VarId,
         new_id: &VarId,
         context: &ModelState,
     ) -> UpdateFn {
-        original_fn.substitute_var(old_id, new_id, context);
+        original_fn.change_var_id(old_id, new_id, context);
         original_fn
     }
 }

--- a/src-tauri/src/sketchbook/observations/_dataset/_impl_dataset.rs
+++ b/src-tauri/src/sketchbook/observations/_dataset/_impl_dataset.rs
@@ -168,7 +168,7 @@ impl Dataset {
     }
 
     /// Add variable to a specific index, and fill its values in all observations with "*"
-    /// placeholders.
+    /// wildcards.
     pub fn add_var_default(&mut self, var_id: VarId, index: usize) -> Result<(), String> {
         self.assert_no_variable(&var_id)?;
         if index > self.num_variables() {
@@ -183,7 +183,7 @@ impl Dataset {
     }
 
     /// Add variable to a specific index, and fill its values in all observations with "*"
-    /// placeholders.
+    /// wildcards.
     pub fn add_var_default_by_str(&mut self, id: &str, index: usize) -> Result<(), String> {
         let var_id = VarId::new(id)?;
         self.add_var_default(var_id, index)

--- a/src-tauri/src/sketchbook/observations/_manager/_impl_session_state.rs
+++ b/src-tauri/src/sketchbook/observations/_manager/_impl_session_state.rs
@@ -307,7 +307,7 @@ impl ObservationManager {
             Some(&ADD_VARIABLE_PATH) => {
                 Self::assert_payload_empty(event, component_name)?;
 
-                // prepare the placeholder var and add it
+                // prepare a placeholder variable name and add it
                 let var_id = self.generate_var_id(&dataset_id, "var", Some(1));
                 self.add_var(&dataset_id, var_id)?;
 

--- a/src-tauri/src/sketchbook/properties/_manager/_impl_manager.rs
+++ b/src-tauri/src/sketchbook/properties/_manager/_impl_manager.rs
@@ -366,6 +366,11 @@ impl PropertyManager {
     ///
     /// This is useful after we change the variable's ID, e.g., to ensure that monotonicity
     /// properties still have IDs like `monotonicity_REGULATOR_TARGET`.
+    ///
+    /// This can be also helpful if we are loading model with potentially invalid IDs (changed by
+    /// the user outside of sketchbook) to fix potential issues.
+    ///
+    /// TODO: extend this with properties for uninterpreted functions
     pub fn make_generated_reg_prop_ids_consistent(&mut self) {
         // list of old-new IDs that must be changed
         let mut id_change_list: Vec<(StatPropertyId, StatPropertyId)> = Vec::new();
@@ -373,7 +378,7 @@ impl PropertyManager {
             match prop.get_prop_data() {
                 StatPropertyType::RegulationEssential(p) => {
                     // this template always has both fields, we can unwrap
-                    let expected_id = StatProperty::get_essentiality_prop_id(
+                    let expected_id = StatProperty::get_reg_essentiality_prop_id(
                         p.input.as_ref().unwrap(),
                         p.target.as_ref().unwrap(),
                     );
@@ -383,7 +388,7 @@ impl PropertyManager {
                 }
                 StatPropertyType::RegulationMonotonic(p) => {
                     // this template always has both fields, we can unwrap
-                    let expected_id = StatProperty::get_monotonicity_prop_id(
+                    let expected_id = StatProperty::get_reg_monotonicity_prop_id(
                         p.input.as_ref().unwrap(),
                         p.target.as_ref().unwrap(),
                     );

--- a/src-tauri/src/sketchbook/properties/_manager/_impl_manager.rs
+++ b/src-tauri/src/sketchbook/properties/_manager/_impl_manager.rs
@@ -369,7 +369,7 @@ impl PropertyManager {
     ///
     /// This can be also helpful if we are loading model with potentially invalid IDs (changed by
     /// the user outside of Sketchbook) to fix potential issues.
-    pub fn make_generated_reg_prop_ids_consistent(&mut self) {
+    pub fn make_generated_reg_prop_ids_consistent(&mut self) -> Result<(), String> {
         // first, collect a list of old-new ID pairs that must be changed
         let mut id_change_list: Vec<(StatPropertyId, StatPropertyId)> = Vec::new();
         for (prop_id, prop) in self.stat_properties.iter() {
@@ -399,8 +399,10 @@ impl PropertyManager {
         }
         // and finally, set the IDs
         for (current_id, new_id) in id_change_list {
-            self.set_stat_id(&current_id, new_id).unwrap();
+            self.set_stat_id(&current_id, new_id)
+                .map_err(|e| format!("Can't standardize ID for property `{current_id}`: {e}"))?;
         }
+        Ok(())
     }
 
     /// Go through all static properties that are automatically generated from the uninterpreted
@@ -411,7 +413,7 @@ impl PropertyManager {
     ///
     /// This can be also helpful if we are loading model with potentially invalid IDs (changed by
     /// the user outside of Sketchbook) to fix potential issues.
-    pub fn make_generated_fn_prop_ids_consistent(&mut self) {
+    pub fn make_generated_fn_prop_ids_consistent(&mut self) -> Result<(), String> {
         // first, collect a list of old-new ID pairs that must be changed
         let mut id_change_list: Vec<(StatPropertyId, StatPropertyId)> = Vec::new();
         for (prop_id, prop) in self.stat_properties.iter() {
@@ -441,8 +443,10 @@ impl PropertyManager {
         }
         // and finally, set the IDs
         for (current_id, new_id) in id_change_list {
-            self.set_stat_id(&current_id, new_id).unwrap();
+            self.set_stat_id(&current_id, new_id)
+                .map_err(|e| format!("Can't standardize ID for property `{current_id}`: {e}"))?;
         }
+        Ok(())
     }
 }
 

--- a/src-tauri/src/sketchbook/properties/_manager/_impl_session_state.rs
+++ b/src-tauri/src/sketchbook/properties/_manager/_impl_session_state.rs
@@ -83,7 +83,7 @@ impl SessionState for PropertyManager {
                     for (_, prop) in self.stat_properties.iter_mut() {
                         let _ = prop.set_var_id_if_present(old_var_id.clone(), new_var_id.clone());
                     }
-                    self.make_generated_reg_prop_ids_consistent();
+                    self.make_generated_reg_prop_ids_consistent().unwrap(); // this is okay to unwrap here
 
                     // the state change is just a list of all static properties
                     let mut properties_list: Vec<StatPropertyData> = self
@@ -122,7 +122,7 @@ impl SessionState for PropertyManager {
                     for (_, prop) in self.stat_properties.iter_mut() {
                         let _ = prop.set_fn_id_if_present(old_fn_id.clone(), new_fn_id.clone());
                     }
-                    self.make_generated_fn_prop_ids_consistent();
+                    self.make_generated_fn_prop_ids_consistent().unwrap(); // this is okay to unwrap here
 
                     // the state change is just a list of all static properties
                     let mut properties_list: Vec<StatPropertyData> = self

--- a/src-tauri/src/sketchbook/properties/dynamic_props/_hctl_formula.rs
+++ b/src-tauri/src/sketchbook/properties/dynamic_props/_hctl_formula.rs
@@ -107,6 +107,7 @@ impl HctlFormula {
     /// whether the propositions correspond to valid network variables used in the `model`.
     pub fn check_syntax_with_model(formula: &str, model: &ModelState) -> Result<(), String> {
         // create simplest bn possible, we just need to cover all the variables
+        // this BN instance does not need any parameters, as these cant appear in HCTL formulas
         let bn = model.to_empty_bn();
         let ctx = SymbolicContext::new(&bn)?;
 

--- a/src-tauri/src/sketchbook/properties/shortcuts.rs
+++ b/src-tauri/src/sketchbook/properties/shortcuts.rs
@@ -1,4 +1,4 @@
-use crate::sketchbook::ids::VarId;
+use crate::sketchbook::ids::{UninterpretedFnId, VarId};
 use crate::sketchbook::model::{Essentiality, Monotonicity};
 use crate::sketchbook::properties::StatProperty;
 
@@ -14,7 +14,7 @@ pub fn mk_fol_prop(formula: &str) -> Result<StatProperty, String> {
 /// Shorthand to get a static property that describes essentiality of a regulation
 /// between `regulator` and `target`.
 /// Chosen name is generic and annotation is empty.
-pub fn mk_essentiality_prop(
+pub fn mk_reg_essentiality_prop(
     regulator: &VarId,
     target: &VarId,
     essentiality: Essentiality,
@@ -32,7 +32,7 @@ pub fn mk_essentiality_prop(
 /// Shorthand to get a static property that describes monotonicity of a regulation
 /// between `regulator` and `target`.
 /// Chosen name is generic and annotation is empty.
-pub fn mk_monotonicity_prop(
+pub fn mk_reg_monotonicity_prop(
     regulator: &VarId,
     target: &VarId,
     monotonicity: Monotonicity,
@@ -42,6 +42,42 @@ pub fn mk_monotonicity_prop(
         name_str,
         Some(regulator.clone()),
         Some(target.clone()),
+        monotonicity,
+        "",
+    )
+}
+
+/// Shorthand to get a static property that describes that argument of an
+/// uninterpreted function `fn_id` on index `index` is essential.
+/// Chosen name is generic and annotation is empty.
+pub fn mk_fn_input_essentiality_prop(
+    fn_id: &UninterpretedFnId,
+    index: usize,
+    essentiality: Essentiality,
+) -> StatProperty {
+    let name_str = "Fn input essential (generated)";
+    StatProperty::mk_fn_input_essential(
+        name_str,
+        Some(index),
+        Some(fn_id.clone()),
+        essentiality,
+        "",
+    )
+}
+
+/// Shorthand to get a static property that describes that argument of an
+/// uninterpreted function `fn_id` on index `index` is monotonic.
+/// Chosen name is generic and annotation is empty.
+pub fn mk_fn_input_monotonicity_prop(
+    fn_id: &UninterpretedFnId,
+    index: usize,
+    monotonicity: Monotonicity,
+) -> StatProperty {
+    let name_str = "Fn input monotonic (generated)";
+    StatProperty::mk_fn_input_monotonic(
+        name_str,
+        Some(index),
+        Some(fn_id.clone()),
         monotonicity,
         "",
     )

--- a/src-tauri/src/sketchbook/properties/static_props/_first_order_formula.rs
+++ b/src-tauri/src/sketchbook/properties/static_props/_first_order_formula.rs
@@ -86,6 +86,8 @@ impl FirstOrderFormula {
     /// so on).
     pub fn check_syntax_with_model(formula: &str, model: &ModelState) -> Result<(), String> {
         let bn = model.to_bn();
+        // before creating symbolic context, we must prune unused parameters or it will fail with an error
+        let bn = bn.prune_unused_parameters();
         let ctx = SymbolicContext::new(&bn)?;
 
         // we have to provide some placeholder name (for minimization), but it does not matter here

--- a/src-tauri/src/sketchbook/properties/static_props/_static_property.rs
+++ b/src-tauri/src/sketchbook/properties/static_props/_static_property.rs
@@ -577,11 +577,11 @@ impl StatProperty {
     }
 }
 
-/// Static methods to automatically generate IDs to encode regulation properties.
+/// Static methods to create standard IDs for automatically generated static properties.
 impl StatProperty {
     /// Get ID of a static property that describes monotonicity of a regulation
     /// between `regulator` and `target`.
-    pub fn get_monotonicity_prop_id(regulator: &VarId, target: &VarId) -> StatPropertyId {
+    pub fn get_reg_monotonicity_prop_id(regulator: &VarId, target: &VarId) -> StatPropertyId {
         let id_str = format!("monotonicity_{}_{}", regulator, target);
         // this will always be a valid ID string, we can unwrap
         StatPropertyId::new(&id_str).unwrap()
@@ -589,8 +589,30 @@ impl StatProperty {
 
     /// Get ID of a static property that describes essentiality of a regulation
     /// between `regulator` and `target`.
-    pub fn get_essentiality_prop_id(regulator: &VarId, target: &VarId) -> StatPropertyId {
+    pub fn get_reg_essentiality_prop_id(regulator: &VarId, target: &VarId) -> StatPropertyId {
         let id_str = format!("essentiality_{}_{}", regulator, target);
+        // this will always be a valid ID string, we can unwrap
+        StatPropertyId::new(&id_str).unwrap()
+    }
+
+    /// Get ID of a static property that describes monotonicity of input on given `index`
+    /// for function `fn_id`.
+    pub fn get_fn_input_monotonicity_prop_id(
+        fn_id: &UninterpretedFnId,
+        index: usize,
+    ) -> StatPropertyId {
+        let id_str = format!("fn_monotonicity_{}_{}", fn_id, index);
+        // this will always be a valid ID string, we can unwrap
+        StatPropertyId::new(&id_str).unwrap()
+    }
+
+    /// Get ID of a static property that describes essentiality of input on given `index`
+    /// for function `fn_id`.
+    pub fn get_fn_input_essentiality_prop_id(
+        fn_id: &UninterpretedFnId,
+        index: usize,
+    ) -> StatPropertyId {
+        let id_str = format!("fn_essentiality_{}_{}", fn_id, index);
         // this will always be a valid ID string, we can unwrap
         StatPropertyId::new(&id_str).unwrap()
     }

--- a/src/aeon_state.ts
+++ b/src/aeon_state.ts
@@ -242,7 +242,7 @@ interface AeonState {
       removeVariable: (varId: string) => void
       /** VariableData (with updated name or annotation) for a modified variable. */
       variableDataChanged: Observable<VariableData>
-      /** Set a variable data for a var with given ID. */
+      /** Set a variable data (name and annotation) for a var with given ID. */
       setVariableData: (varId: string, variableData: VariableData) => void
       /** ModelData after variable's ID is changed.
        * Since variable ID change can affect many parts of the model (update fns, regulations, ...), we
@@ -268,20 +268,12 @@ interface AeonState {
       removeUninterpretedFn: (uninterpretedFnId: string) => void
       /** UninterpretedFnData (with updated name or annotation) for a modified uninterpreted function. */
       uninterpretedFnDataChanged: Observable<UninterpretedFnData>
-      /** Set data of uninterpreted function with given ID. */
+      /** Set data (name, annotation) of uninterpreted function with given ID. */
       setUninterpretedFnData: (uninterpretedFnId: string, fnData: UninterpretedFnData) => void
       /** UninterpretedFnData (with updated `arity`) for a modified uninterpreted function. */
       uninterpretedFnArityChanged: Observable<UninterpretedFnData>
       /** Set arity of uninterpreted function with given ID. */
       setUninterpretedFnArity: (uninterpretedFnId: string, newArity: number) => void
-      /** UninterpretedFnData (with incremented `arity`) for a modified uninterpreted function. */
-      uninterpretedFnArityIncremented: Observable<UninterpretedFnData>
-      /** Increment arity of uninterpreted function with given ID. */
-      incrementUninterpretedFnArity: (uninterpretedFnId: string) => void
-      /** UninterpretedFnData (with decremented `arity`) for a modified uninterpreted function. */
-      uninterpretedFnArityDecremented: Observable<UninterpretedFnData>
-      /** Decrement arity of uninterpreted function with given ID. */
-      decrementUninterpretedFnArity: (uninterpretedFnId: string) => void
       /** ModelData after function's ID is changed.
        * Since function ID change can affect many parts of the model (update fns, other uninterpreted fns, ...), we
        * get the whole model data at once. */
@@ -681,8 +673,6 @@ export const aeonState: AeonState = {
       uninterpretedFnRemoved: new Observable<UninterpretedFnData>(['sketch', 'model', 'uninterpreted_fn', 'remove']),
       uninterpretedFnDataChanged: new Observable<UninterpretedFnData>(['sketch', 'model', 'uninterpreted_fn', 'set_data']),
       uninterpretedFnArityChanged: new Observable<UninterpretedFnData>(['sketch', 'model', 'uninterpreted_fn', 'set_arity']),
-      uninterpretedFnArityIncremented: new Observable<UninterpretedFnData>(['sketch', 'model', 'uninterpreted_fn', 'increment_arity']),
-      uninterpretedFnArityDecremented: new Observable<UninterpretedFnData>(['sketch', 'model', 'uninterpreted_fn', 'decrement_arity']),
       uninterpretedFnIdChanged: new Observable<ModelData>(['sketch', 'model', 'uninterpreted_fn', 'set_id']),
       uninterpretedFnExpressionChanged: new Observable<UninterpretedFnData>(['sketch', 'model', 'uninterpreted_fn', 'set_expression']),
       uninterpretedFnMonotonicityChanged: new Observable<UninterpretedFnData>(['sketch', 'model', 'uninterpreted_fn', 'set_monotonicity']),
@@ -754,18 +744,6 @@ export const aeonState: AeonState = {
         aeonEvents.emitAction({
           path: ['sketch', 'model', 'uninterpreted_fn', uninterpretedFnId, 'set_arity'],
           payload: newArity.toString()
-        })
-      },
-      incrementUninterpretedFnArity (uninterpretedFnId: string): void {
-        aeonEvents.emitAction({
-          path: ['sketch', 'model', 'uninterpreted_fn', uninterpretedFnId, 'increment_arity'],
-          payload: null
-        })
-      },
-      decrementUninterpretedFnArity (uninterpretedFnId: string): void {
-        aeonEvents.emitAction({
-          path: ['sketch', 'model', 'uninterpreted_fn', uninterpretedFnId, 'decrement_arity'],
-          payload: null
         })
       },
       setUninterpretedFnId (originalId: string, newId: string): void {

--- a/src/aeon_state.ts
+++ b/src/aeon_state.ts
@@ -460,8 +460,8 @@ interface AeonState {
       staticIdChanged: Observable<StatPropIdUpdateData>
       /** Set ID of static property with given original ID to a new id. */
       setStaticId: (originalId: string, newId: string) => void
-      /** List of all `StaticProperty` after variable's ID is changed.
-       * Since var ID change can affect any property, we "refresh" all data at once. */
+      /** List of all `StaticProperty` after variable's ID or function's ID is changed.
+       * Since these ID changes can affect multiple properties, we "refresh" all data at once. */
       allStaticUpdated: Observable<StaticProperty[]>
     }
   }
@@ -964,7 +964,7 @@ export const aeonState: AeonState = {
       staticContentChanged: new Observable<StaticProperty>(['sketch', 'properties', 'static', 'set_content']),
       staticRemoved: new Observable<StaticProperty>(['sketch', 'properties', 'static', 'remove']),
       staticIdChanged: new Observable<StatPropIdUpdateData>(['sketch', 'properties', 'static', 'set_id']),
-      allStaticUpdated: new Observable<StaticProperty[]>(['sketch', 'properties', 'static', 'set_var_id_everywhere']),
+      allStaticUpdated: new Observable<StaticProperty[]>(['sketch', 'properties', 'static', 'all_static_updated']),
 
       addDefaultDynamic (variant: DynamicPropertyType): void {
         aeonEvents.emitAction({

--- a/src/html/component-analysis/analysis-component/analysis-component.ts
+++ b/src/html/component-analysis/analysis-component/analysis-component.ts
@@ -147,7 +147,7 @@ export default class AnalysisComponent extends LitElement {
   #onComputationErrorMessageReceived (message: string): void {
     console.log(message)
     this.waitingMainMessage = 'Inference computation ended with an error.<br>'
-    this.waitingProgressReport = 'Error running inference:\n\n' + message
+    this.waitingProgressReport = 'Internal solver error during inference:\n\n' + message
 
     // stop pinging backend
     clearInterval(this.pingIntervalId)

--- a/src/html/component-editor/functions-editor/editor-tile/editor-tile.less
+++ b/src/html/component-editor/functions-editor/editor-tile/editor-tile.less
@@ -33,18 +33,6 @@
   width: 99%;
 }
 
-.remove-reg {
-  height: 24px;
-  line-height: 24px;
-  padding: 0;
-  width: 24px;  
-  align-self: start;
-}
-
-.remove-reg .fa-trash {
-  height: 10px;
-}
-
 .functions-body {
   flex-direction: column;
 }
@@ -77,10 +65,26 @@
   .regulation:hover {
     background: rgba(0, 0, 0, 0.37);
   }
+
+  .function-id-field {
+    color: @text-dark;
+  }
+
+  .uk-form-label {
+    color: @text-dark;
+  }
 }
 
 @media (prefers-color-scheme: light) {
   .regulation:hover {
     background: rgba(0, 0, 0, 0.05);
+  }
+  
+  .function-id-field {
+    color: @text-light;
+  }
+
+  .uk-form-label {
+    color: @text-light;
   }
 }

--- a/src/html/component-editor/functions-editor/editor-tile/editor-tile.ts
+++ b/src/html/component-editor/functions-editor/editor-tile/editor-tile.ts
@@ -106,5 +106,5 @@ export abstract class EditorTile extends LitElement {
 
   abstract toggleEssentiality (regulation: IRegulationData): void
   abstract toggleMonotonicity (regulation: IRegulationData): void
-  abstract removeVariable (): void
+  abstract removeElement (): void
 }

--- a/src/html/component-editor/functions-editor/editor-tile/function-tile.ts
+++ b/src/html/component-editor/functions-editor/editor-tile/function-tile.ts
@@ -18,7 +18,6 @@ library.add(faTrash, faMagnifyingGlass, faAngleDown, faAngleUp, faClose, faMinus
 @customElement('function-tile')
 export class FunctionTile extends EditorTile {
   @state() bodyVisible = false
-  varIndex = 0
 
   constructor () {
     super()
@@ -51,7 +50,7 @@ export class FunctionTile extends EditorTile {
   }
 
   nameUpdated = debounce((name: string) => {
-    this.dispatchEvent(new CustomEvent('rename-function-definition', {
+    this.dispatchEvent(new CustomEvent('change-function-id', {
       detail: {
         oldId: this.functions[this.index].id,
         newId: name
@@ -95,30 +94,28 @@ export class FunctionTile extends EditorTile {
   }
 
   private addVariable (): void {
-    this.dispatchEvent(new CustomEvent('add-function-variable', {
+    this.dispatchEvent(new CustomEvent('change-fn-arity', {
       detail: {
         id: this.functions[this.index].id,
-        variable: 'var' + this.varIndex
+        arity: this.functions[this.index].variables.length + 1
       },
       bubbles: true,
       composed: true
     }))
-    this.varIndex++
     this.bodyVisible = true
   }
 
   private async removeVariable (): Promise<void> {
-    if (this.varIndex <= 0) {
+    if (this.functions[this.index].variables.length <= 0) {
       await dialog.message("You can't decrement function arity below zero.", {
         type: 'error',
         title: 'Error'
       })
     } else {
-      this.varIndex--
-      this.dispatchEvent(new CustomEvent('remove-function-variable', {
+      this.dispatchEvent(new CustomEvent('change-fn-arity', {
         detail: {
           id: this.functions[this.index].id,
-          variable: 'var' + this.varIndex
+          arity: this.functions[this.index].variables.length - 1
         },
         bubbles: true,
         composed: true

--- a/src/html/component-editor/functions-editor/editor-tile/function-tile.ts
+++ b/src/html/component-editor/functions-editor/editor-tile/function-tile.ts
@@ -4,15 +4,16 @@ import { map } from 'lit/directives/map.js'
 import { type IRegulationData } from '../../../util/data-interfaces'
 import { debounce } from 'lodash'
 import { icon, library } from '@fortawesome/fontawesome-svg-core'
-import { faMagnifyingGlass, faTrash, faPlus, faAngleDown, faAngleUp, faClose, faPen } from '@fortawesome/free-solid-svg-icons'
+import { faMagnifyingGlass, faTrash, faPlus, faMinus, faAngleDown, faAngleUp, faClose, faEdit } from '@fortawesome/free-solid-svg-icons'
 import ace, { type Ace } from 'ace-builds'
 import langTools from 'ace-builds/src-noconflict/ext-language_tools'
 import 'ace-builds/esm-resolver'
 import { EditorTile } from './editor-tile'
 import { functionDebounceTimer } from '../../../util/config'
 import { getEssentialityText, getMonotonicityClass } from '../../../util/utilities'
+import { dialog } from '@tauri-apps/api'
 
-library.add(faTrash, faMagnifyingGlass, faAngleDown, faAngleUp, faClose)
+library.add(faTrash, faMagnifyingGlass, faAngleDown, faAngleUp, faClose, faMinus)
 
 @customElement('function-tile')
 export class FunctionTile extends EditorTile {
@@ -83,7 +84,7 @@ export class FunctionTile extends EditorTile {
     }))
   }
 
-  async removeVariable (): Promise<void> {
+  async removeElement (): Promise<void> {
     this.dispatchEvent(new CustomEvent('remove-function-definition', {
       detail: {
         id: this.functions[this.index].id
@@ -104,6 +105,26 @@ export class FunctionTile extends EditorTile {
     }))
     this.varIndex++
     this.bodyVisible = true
+  }
+
+  private async removeVariable (): Promise<void> {
+    if (this.varIndex <= 0) {
+      await dialog.message("You can't decrement function arity below zero.", {
+        type: 'error',
+        title: 'Error'
+      })
+    } else {
+      this.varIndex--
+      this.dispatchEvent(new CustomEvent('remove-function-variable', {
+        detail: {
+          id: this.functions[this.index].id,
+          variable: 'var' + this.varIndex
+        },
+        bubbles: true,
+        composed: true
+      }))
+      this.bodyVisible = true
+    }
   }
 
   toggleEssentiality (regulation: IRegulationData): void {
@@ -154,7 +175,7 @@ export class FunctionTile extends EditorTile {
   protected render (): TemplateResult {
     return html`
       <div class="container uk-flex uk-flex-column uk-margin-small-bottom">
-        <div class="uk-flex uk-flex-row">
+        <div class="uk-flex uk-flex-row uk-margin-small-bottom">
           <input id="name-field" class="uk-input uk-text-center" .value="${this.functions[this.index].id}"
                  @input="${(e: InputEvent) => this.nameUpdated((e.target as HTMLInputElement).value)}"/>
           
@@ -162,11 +183,15 @@ export class FunctionTile extends EditorTile {
             ${icon(faPlus).node}
           </button>
           
-          <button class="icon-button uk-button uk-button-small uk-button-secondary" @click="${this.editFunction}">
-            ${icon(faPen).node}
+          <button class="icon-button uk-button uk-button-small uk-button-secondary" @click="${this.removeVariable}">
+            ${icon(faMinus).node}
           </button>
 
-          <button class="icon-button uk-button uk-button-small uk-button-secondary" @click="${this.removeVariable}">
+          <button class="icon-button uk-button uk-button-small uk-button-secondary" @click="${this.editFunction}">
+            ${icon(faEdit).node}
+          </button>
+
+          <button class="icon-button uk-button uk-button-small uk-button-secondary" @click="${this.removeElement}">
             ${icon(faTrash).node}
           </button>
           
@@ -177,16 +202,11 @@ export class FunctionTile extends EditorTile {
             </div>
           </button>
         </div>
+
         <div class="functions-body" style="display: ${this.bodyVisible ? 'flex' : 'none'}">
-        ${this.functions[this.index].variables.length > 0 ? html`<span class="uk-text-left uk-margin-remove">Regulators:</span>` : ''} 
+        ${this.functions[this.index].variables.length > 0 ? html`<span class="uk-text-left uk-margin-remove">Formal arguments and their effects:</span>` : ''} 
           ${map(this.functions[this.index].variables, (variable) => html`
-            <div
-                class="regulation uk-grid uk-grid-column-small uk-grid-row-large uk-child-width-1-4 uk-margin-remove uk-text-center uk-flex-around uk-text-nowrap">
-              <button class="remove-reg uk-width-1-6 uk-button uk-button-small uk-button-secondary" @click="${() => {
-                void this.removeRegulation(variable)
-              }}">
-                ${icon(faClose).node}
-              </button>
+            <div class="regulation uk-grid uk-grid-column-small uk-grid-row-large uk-child-width-1-4 uk-margin-remove uk-text-center uk-flex-around uk-text-nowrap">
               <div class="uk-width-1-6">${variable.source}</div>
               <div class="uk-width-1-6">${this.getRegulationSymbol(variable.essential, variable.monotonicity)}</div>
               <div class="regulation-property"

--- a/src/html/component-editor/functions-editor/editor-tile/variable-tile.ts
+++ b/src/html/component-editor/functions-editor/editor-tile/variable-tile.ts
@@ -104,7 +104,7 @@ export class VariableTile extends EditorTile {
     }))
   }
 
-  removeVariable (): void {
+  removeElement (): void {
     this.shadowRoot?.dispatchEvent(new CustomEvent('remove-variable', {
       detail: {
         id: this.variables[this.index].id
@@ -152,11 +152,11 @@ export class VariableTile extends EditorTile {
           <button class="icon-button uk-button uk-button-small uk-button-secondary" @click="${this.focusVariable}">
             ${icon(faMagnifyingGlass).node}
           </button>
-          <button class="icon-button uk-button uk-button-small uk-button-secondary" @click="${this.removeVariable}">
+          <button class="icon-button uk-button uk-button-small uk-button-secondary" @click="${this.removeElement}">
             ${icon(faTrash).node}
           </button>
         </div>
-        ${this.regulations.length > 0 ? html`<span class="uk-text-left uk-margin-remove">Regulators:</span>` : ''}        
+        ${this.regulations.length > 0 ? html`<span class="uk-text-left uk-margin-remove">Regulators and their effects:</span>` : ''}        
         ${map(this.regulations, (regulation) => html`
           <div
               class="regulation uk-grid uk-grid-column-small uk-grid-row-large uk-child-width-1-4 uk-margin-remove uk-text-center uk-flex-around uk-text-nowrap"

--- a/src/html/component-editor/functions-editor/functions-editor.ts
+++ b/src/html/component-editor/functions-editor/functions-editor.ts
@@ -35,7 +35,7 @@ export class FunctionsEditor extends LitElement {
     this.addEventListener('change-function-id', this.setFunctionId)
     // listener 'aeonState.sketch.model.uninterpretedFnIdChanged' is handled by Root component (more complex update)
     this.addEventListener('change-fn-arity', this.changeFunctionArity)
-    aeonState.sketch.model.uninterpretedFnArityChanged.addEventListener(this.#onFunctionArityChanged.bind(this))
+    // listener 'aeonState.sketch.model.uninterpretedFnArityChanged' is handled by Root component (more complex update)
     this.addEventListener('toggle-function-variable-monotonicity', this.toggleFunctionVariableMonotonicity)
     aeonState.sketch.model.uninterpretedFnMonotonicityChanged.addEventListener(this.#onFunctionMonotonicityChanged.bind(this))
     this.addEventListener('toggle-function-variable-essentiality', this.toggleFunctionVariableEssentiality)
@@ -143,17 +143,6 @@ export class FunctionsEditor extends LitElement {
   private changeFunctionArity (event: Event): void {
     const detail = (event as CustomEvent).detail
     aeonState.sketch.model.setUninterpretedFnArity(detail.id, detail.arity)
-  }
-
-  /** Process and propagate data for a function with updated arity that was sent from backend. */
-  #onFunctionArityChanged (data: UninterpretedFnData): void {
-    const index = this.contentData.functions.findIndex(fun => fun.id === data.id)
-    if (index === -1) return
-
-    const modifiedFunction = convertToIFunction(data)
-    const functions = [...this.contentData.functions]
-    functions[index] = modifiedFunction
-    this.saveFunctions(functions)
   }
 
   /** Invoke backend to toggle function monotonicity. */

--- a/src/html/component-editor/functions-editor/functions-editor.ts
+++ b/src/html/component-editor/functions-editor/functions-editor.ts
@@ -29,9 +29,9 @@ export class FunctionsEditor extends LitElement {
     // functions-related event listeners
     aeonState.sketch.model.uninterpretedFnCreated.addEventListener(this.#onFunctionCreated.bind(this))
     this.addEventListener('remove-function-definition', (e) => { void this.removeFunction(e) })
-    aeonState.sketch.model.uninterpretedFnDataChanged.addEventListener(this.#onFunctionDataChanged.bind(this))
+    // listener 'aeonState.sketch.model.uninterpretedFnRemoved' is handled by Root component (more complex update)
     this.addEventListener('edit-function-definition', (e) => { void this.editFunction(e) })
-    aeonState.sketch.model.uninterpretedFnRemoved.addEventListener(this.#onFunctionRemoved.bind(this))
+    aeonState.sketch.model.uninterpretedFnDataChanged.addEventListener(this.#onFunctionDataChanged.bind(this))
     this.addEventListener('change-function-id', this.setFunctionId)
     // listener 'aeonState.sketch.model.uninterpretedFnIdChanged' is handled by Root component (more complex update)
     this.addEventListener('change-fn-arity', this.changeFunctionArity)
@@ -131,16 +131,6 @@ export class FunctionsEditor extends LitElement {
     const message = `Do you want to proceed removing function '${id}'?`
     if (!await this.confirmDeleteDialog(message)) return
     aeonState.sketch.model.removeUninterpretedFn(id)
-  }
-
-  /** Process and remove fn data sent from backend. */
-  #onFunctionRemoved (data: UninterpretedFnData): void {
-    const id = data.id
-    const index = this.contentData.functions.findIndex(fun => fun.id === id)
-    if (index === -1) return
-    const functions = [...this.contentData.functions]
-    functions.splice(index, 1)
-    this.saveFunctions(functions)
   }
 
   /** Invoke backend to set function id. */

--- a/src/html/component-editor/functions-editor/functions-editor.ts
+++ b/src/html/component-editor/functions-editor/functions-editor.ts
@@ -32,16 +32,14 @@ export class FunctionsEditor extends LitElement {
     aeonState.sketch.model.uninterpretedFnDataChanged.addEventListener(this.#onFunctionDataChanged.bind(this))
     this.addEventListener('edit-function-definition', (e) => { void this.editFunction(e) })
     aeonState.sketch.model.uninterpretedFnRemoved.addEventListener(this.#onFunctionRemoved.bind(this))
-    this.addEventListener('rename-function-definition', this.setFunctionId)
+    this.addEventListener('change-function-id', this.setFunctionId)
     // listener 'aeonState.sketch.model.uninterpretedFnIdChanged' is handled by Root component (more complex update)
-    this.addEventListener('add-function-variable', this.addFunctionVariable)
-    aeonState.sketch.model.uninterpretedFnArityIncremented.addEventListener(this.#onFunctionArityIncremented.bind(this))
+    this.addEventListener('change-fn-arity', this.changeFunctionArity)
+    aeonState.sketch.model.uninterpretedFnArityChanged.addEventListener(this.#onFunctionArityChanged.bind(this))
     this.addEventListener('toggle-function-variable-monotonicity', this.toggleFunctionVariableMonotonicity)
     aeonState.sketch.model.uninterpretedFnMonotonicityChanged.addEventListener(this.#onFunctionMonotonicityChanged.bind(this))
     this.addEventListener('toggle-function-variable-essentiality', this.toggleFunctionVariableEssentiality)
     aeonState.sketch.model.uninterpretedFnEssentialityChanged.addEventListener(this.#onFunctionEssentialityChanged.bind(this))
-    this.addEventListener('remove-function-variable', (e) => { void this.removeFunctionVariable(e) })
-    aeonState.sketch.model.uninterpretedFnArityDecremented.addEventListener(this.#onFunctionArityDecremented.bind(this))
     this.addEventListener('set-uninterpreted-function-expression', this.setFunctionExpression)
     aeonState.sketch.model.uninterpretedFnExpressionChanged.addEventListener(this.#onFunctionExpressionChanged.bind(this))
 
@@ -151,18 +149,17 @@ export class FunctionsEditor extends LitElement {
     aeonState.sketch.model.setUninterpretedFnId(detail.oldId, detail.newId)
   }
 
-  /** Invoke backend to add variable to a function (incrementing it). */
-  private addFunctionVariable (event: Event): void {
+  /** Invoke backend to change function's arity. */
+  private changeFunctionArity (event: Event): void {
     const detail = (event as CustomEvent).detail
-    aeonState.sketch.model.incrementUninterpretedFnArity(detail.id)
+    aeonState.sketch.model.setUninterpretedFnArity(detail.id, detail.arity)
   }
 
-  /** Process and update incremented fn arity sent from backend. */
-  #onFunctionArityIncremented (data: UninterpretedFnData): void {
+  /** Process and propagate data for a function with updated arity that was sent from backend. */
+  #onFunctionArityChanged (data: UninterpretedFnData): void {
     const index = this.contentData.functions.findIndex(fun => fun.id === data.id)
     if (index === -1) return
 
-    // not most efficient, but probably sufficient and clear
     const modifiedFunction = convertToIFunction(data)
     const functions = [...this.contentData.functions]
     functions[index] = modifiedFunction
@@ -215,24 +212,6 @@ export class FunctionsEditor extends LitElement {
 
   /** Process and update changed fn expression sent from backend. */
   #onFunctionExpressionChanged (data: UninterpretedFnData): void {
-    const index = this.contentData.functions.findIndex(fun => fun.id === data.id)
-    if (index === -1) return
-
-    // not most efficient, but probably sufficient and clear
-    const modifiedFunction = convertToIFunction(data)
-    const functions = [...this.contentData.functions]
-    functions[index] = modifiedFunction
-    this.saveFunctions(functions)
-  }
-
-  /** Invoke backend to remove function's variable (decrementing it). */
-  private async removeFunctionVariable (event: Event): Promise<void> {
-    const detail = (event as CustomEvent).detail
-    aeonState.sketch.model.decrementUninterpretedFnArity(detail.id)
-  }
-
-  /** Process and update decremented fn sent from backend. */
-  #onFunctionArityDecremented (data: UninterpretedFnData): void {
     const index = this.contentData.functions.findIndex(fun => fun.id === data.id)
     if (index === -1) return
 

--- a/src/html/component-editor/properties-editor/dynamic/dynamic-obs-selection/dynamic-obs-selection.ts
+++ b/src/html/component-editor/properties-editor/dynamic/dynamic-obs-selection/dynamic-obs-selection.ts
@@ -85,11 +85,7 @@ export default class DynamicObsSelection extends AbstractDynamicProperty {
                 <select class="uk-select uk-margin-small-left" name="observation" id="observation"
                         @change=${this.observationChanged}
                         ?disabled="${this.property.dataset === null}">
-                  ${when(this.property.variant === DynamicPropertyType.HasAttractor,
-                      () => html`
-                        <option value=${'*'}>all</option>`,
-                      () => html`
-                        <option value=${null}>---</option>`)}
+                        <option value=${'*'}>all</option>
                   ${map(this.observations[this.observations.findIndex(dataset => dataset.id === this.property.dataset)]?.observations,
                       (observation) => html`
                         <option value="${observation.id}">${observation.id}</option>

--- a/src/html/component-editor/properties-editor/properties-editor.ts
+++ b/src/html/component-editor/properties-editor/properties-editor.ts
@@ -394,6 +394,20 @@ export default class PropertiesEditor extends LitElement {
     this.showFunctionProperties = !this.showFunctionProperties
   }
 
+  numGeneratedFnProperties (): number {
+    const generatedFnProps = this.contentData.staticProperties.filter(
+      prop => prop.variant === StaticPropertyType.FunctionInputEssential || prop.variant === StaticPropertyType.FunctionInputMonotonic
+    )
+    return generatedFnProps.length
+  }
+
+  numGeneratedRegProperties (): number {
+    const generatedRegProps = this.contentData.staticProperties.filter(
+      prop => prop.variant === StaticPropertyType.VariableRegulationEssential || prop.variant === StaticPropertyType.VariableRegulationMonotonic
+    )
+    return generatedRegProps.length
+  }
+
   render (): TemplateResult {
     return html`
       <div id="dynamic-property-menu" class="menu-content">
@@ -445,16 +459,21 @@ export default class PropertiesEditor extends LitElement {
                   <span class="uk-label">No static properties defined</span>
               </div>`
 : html`
-              <div class="uk-margin-small">
+              ${this.numGeneratedRegProperties() > 0
+? html`<div class="uk-margin-small">
                 <button class="uk-button uk-button-small uk-button-primary uk-margin-bottom" @click="${this.toggleRegulationPropertiesVisibility}">
                   ${this.showRegulationProperties ? 'Hide' : 'Show'} Generated Regulation Properties
                 </button>
-              </div>
-              <div class="uk-margin-small">
+              </div>`
+: html``}
+
+              ${this.numGeneratedFnProperties() > 0
+? html`<div class="uk-margin-small">
                 <button class="uk-button uk-button-small uk-button-primary uk-margin-bottom" @click="${this.toggleFunctionPropertiesVisibility}">
                   ${this.showFunctionProperties ? 'Hide' : 'Show'} Generated Function Properties
                 </button>
-              </div>`}
+              </div>`
+: html``}`}
             <div class="section-list">
               ${map(this.contentData.staticProperties, (prop, index) => {
                 let result = html``

--- a/src/html/component-editor/properties-editor/properties-editor.ts
+++ b/src/html/component-editor/properties-editor/properties-editor.ts
@@ -83,13 +83,13 @@ export default class PropertiesEditor extends LitElement {
     this.addEventListener('dynamic-property-edited', (e) => { void this.editDynProperty(e) })
     this.addEventListener('static-property-edited', (e) => { void this.editStatProperty(e) })
 
-    // refresh-event listeners (or listeners to events that update the whole list of props)
+    // refresh-event listeners (or listeners to events that update whole property sets)
     aeonState.sketch.properties.staticPropsRefreshed.addEventListener(this.#onStaticRefreshed.bind(this))
     aeonState.sketch.properties.dynamicPropsRefreshed.addEventListener(this.#onDynamicRefreshed.bind(this))
     aeonState.sketch.properties.allStaticUpdated.addEventListener(this.#onStaticRefreshed.bind(this))
 
     // note that the refresh events are automatically triggered or handled (after app refresh) directly
-    // from the root component (due to some dependency issues between different components)
+    // from the root component (due to some dependency issues between different components of the sketch)
   }
 
   protected updated (_changedProperties: PropertyValues): void {

--- a/src/html/component-editor/properties-editor/properties-editor.ts
+++ b/src/html/component-editor/properties-editor/properties-editor.ts
@@ -38,6 +38,8 @@ export default class PropertiesEditor extends LitElement {
   @state() addStaticMenuVisible = false
   // visibility of automatically generated regulation properties
   @state() showRegulationProperties = true
+  // visibility of automatically generated function properties
+  @state() showFunctionProperties = true
   // static prop edit dialogs
   dialogsStatic: Record<string, WebviewWindow | undefined> = {}
   // dynamic prop edit dialogs
@@ -388,6 +390,10 @@ export default class PropertiesEditor extends LitElement {
     this.showRegulationProperties = !this.showRegulationProperties
   }
 
+  toggleFunctionPropertiesVisibility (): void {
+    this.showFunctionProperties = !this.showFunctionProperties
+  }
+
   render (): TemplateResult {
     return html`
       <div id="dynamic-property-menu" class="menu-content">
@@ -443,6 +449,11 @@ export default class PropertiesEditor extends LitElement {
                 <button class="uk-button uk-button-small uk-button-primary uk-margin-bottom" @click="${this.toggleRegulationPropertiesVisibility}">
                   ${this.showRegulationProperties ? 'Hide' : 'Show'} Generated Regulation Properties
                 </button>
+              </div>
+              <div class="uk-margin-small">
+                <button class="uk-button uk-button-small uk-button-primary uk-margin-bottom" @click="${this.toggleFunctionPropertiesVisibility}">
+                  ${this.showFunctionProperties ? 'Hide' : 'Show'} Generated Function Properties
+                </button>
               </div>`}
             <div class="section-list">
               ${map(this.contentData.staticProperties, (prop, index) => {
@@ -456,11 +467,16 @@ export default class PropertiesEditor extends LitElement {
                       </static-generic>`
                     break
                   case StaticPropertyType.FunctionInputEssential:
-                    result = html`
-                      <static-input-essential .index=${index}
-                                              .property=${prop}>
-                      </static-input-essential>`
-                    break
+                    // Only render this if showFunctionProperties is true
+                    if (this.showFunctionProperties) {
+                      result = html`
+                        <static-input-essential .index=${index}
+                                                .property=${prop}>
+                        </static-input-essential>`
+                        break
+                    } else {
+                      return html``
+                    }
                   case StaticPropertyType.VariableRegulationEssential:
                     // Only render this if showRegulationProperties is true
                     if (this.showRegulationProperties) {
@@ -481,11 +497,16 @@ export default class PropertiesEditor extends LitElement {
                       </static-input-essential-condition>`
                     break
                   case StaticPropertyType.FunctionInputMonotonic:
-                    result = html`
-                      <static-input-monotonic .index=${index}
-                                              .property=${prop}>
-                      </static-input-monotonic>`
-                    break
+                    // Only render this if showFunctionProperties is true
+                    if (this.showFunctionProperties) {
+                      result = html`
+                        <static-input-monotonic .index=${index}
+                                                .property=${prop}>
+                        </static-input-monotonic>`
+                        break
+                    } else {
+                      return html``
+                    }
                   case StaticPropertyType.VariableRegulationMonotonic:
                     // Only render this if showRegulationProperties is true
                     if (this.showRegulationProperties) {

--- a/src/html/component-editor/properties-editor/static/abstract-static-property.ts
+++ b/src/html/component-editor/properties-editor/static/abstract-static-property.ts
@@ -40,11 +40,12 @@ export default class abstractStaticProperty extends AbstractProperty {
           <label class="uk-form-label" for="id-field">ID</label>
           <input id="id-field" class="uk-input static-name-field" .value="${this.property.id}" readonly/>
         </div>
+
         <div class="uk-flex uk-flex-column name-section">
           <label class="uk-form-label" for="name-field">NAME</label>
           <input id="name-field" class="name-field static-name-field" .value="${this.property.name}" readonly/>
-
         </div>
+        
         ${when(removeButton, () => html`
           <button class="remove-property uk-button uk-button-secondary uk-button-small" @click="${this.editStatProperty}">
             ${icon(faEdit).node}

--- a/src/html/component-editor/regulations-editor/float-menu/float-menu.ts
+++ b/src/html/component-editor/regulations-editor/float-menu/float-menu.ts
@@ -10,7 +10,7 @@ import {
   faEye,
   faEyeLowVision,
   faEyeSlash,
-  faPen,
+  faEdit,
   faPlus,
   faRightLeft,
   faTrash,
@@ -27,7 +27,7 @@ import {
 } from '../../../util/data-interfaces'
 import { when } from 'lit/directives/when.js'
 
-library.add(faRightLeft, faArrowTrendUp, faArrowTrendDown, faCalculator, faEye, faEyeSlash, faPen, faTrash, faPlus)
+library.add(faRightLeft, faArrowTrendUp, faArrowTrendDown, faCalculator, faEye, faEyeSlash, faEdit, faTrash, faPlus)
 
 @customElement('float-menu')
 export default class FloatMenu extends LitElement {
@@ -85,7 +85,7 @@ export default class FloatMenu extends LitElement {
 
   nodeButtons: IButton[] = [
     {
-      icon: () => icon(faPen).node[0],
+      icon: () => icon(faEdit).node[0],
       label: () => 'Edit variable (E)',
       click: this.editVariable
     },

--- a/src/html/component-editor/root-component/root-component.ts
+++ b/src/html/component-editor/root-component/root-component.ts
@@ -99,11 +99,11 @@ export default class RootComponent extends LitElement {
     // Some changes to uninterpreted functions can affect many parts of the sketch (update fns, other
     // uninterpreted fns, properties,...). Therefore, we process them here, instead of doing it in
     // the function editor, because here we have access to the whole sketch.
-    // 1) After fn ID change, we refresh the whole model data.
+    // 1) After fn ID change, we receive the whole model data.
     aeonState.sketch.model.uninterpretedFnIdChanged.addEventListener(this.#onModelRefreshed.bind(this))
-    // 2) After fn removal, we refresh the static properties.
+    // 2) After fn removal, we we call backend to refresh the static properties.
     aeonState.sketch.model.uninterpretedFnRemoved.addEventListener(this.#onFunctionRemoved.bind(this))
-    // 3) After changing fn arity, we refresh the static properties.
+    // 3) After changing fn arity, we call backend to refresh the static properties.
     aeonState.sketch.model.uninterpretedFnArityChanged.addEventListener(this.#onFunctionArityChanged.bind(this))
 
     // listeners for refresh events from backend

--- a/src/html/component-editor/root-component/root-component.ts
+++ b/src/html/component-editor/root-component/root-component.ts
@@ -7,7 +7,7 @@ import '../nav-bar/nav-bar'
 import '../initial-screen/initial-screen'
 import { type TabData } from '../../util/tab-data'
 import {
-  aeonState, type LayoutNodeData, type LayoutNodeDataPrototype,
+  aeonState, type UninterpretedFnData, type LayoutNodeData, type LayoutNodeDataPrototype,
   type ModelData, type RegulationData, type SketchData, type VariableData
 } from '../../../aeon_state'
 import { tabList } from '../../util/config'
@@ -96,6 +96,14 @@ export default class RootComponent extends LitElement {
     this.addEventListener('remove-regulation', (e) => { void this.removeRegulation(e) })
     aeonState.sketch.model.regulationRemoved.addEventListener(this.#onRegulationRemoved.bind(this))
 
+    // Some changes to uninterpreted functions can affect many parts of the sketch (update fns, other
+    // uninterpreted fns, properties,...). Therefore, we process them here, instead of doing it in
+    // the function editor, because here we have access to the whole sketch.
+    // 1) After fn ID change, we refresh the whole model data.
+    aeonState.sketch.model.uninterpretedFnIdChanged.addEventListener(this.#onModelRefreshed.bind(this))
+    // 2) After fn removal, we refresh the static properties.
+    aeonState.sketch.model.uninterpretedFnRemoved.addEventListener(this.#onFunctionRemoved.bind(this))
+
     // listeners for refresh events from backend
     aeonState.sketch.model.modelRefreshed.addEventListener(this.#onModelRefreshed.bind(this))
     aeonState.sketch.model.variablesRefreshed.addEventListener(this.#onVariablesRefreshed.bind(this))
@@ -113,10 +121,6 @@ export default class RootComponent extends LitElement {
     this.addEventListener('save-dynamic-properties', this.saveDynamicPropertyData.bind(this))
     this.addEventListener('save-static-properties', this.saveStaticPropertyData.bind(this))
     this.addEventListener('save-annotation', this.saveAnnotationData.bind(this))
-
-    // Since function ID change can affect many parts of the model (update fns, other uninterpreted fns, ...),
-    // the event fetches the whole updated model data, and we make the change here in the root component.
-    aeonState.sketch.model.uninterpretedFnIdChanged.addEventListener(this.#onModelRefreshed.bind(this))
 
     // load variable editorStarted from session storage (so it survives refresh)
     const storedEditorStarted = sessionStorage.getItem('editorStarted')
@@ -613,10 +617,26 @@ export default class RootComponent extends LitElement {
       this.data.regulations.filter((regulation) => regulation.source !== data.regulator || regulation.target !== data.target)
     )
 
-    // a hacky way to avoid issues in static properties after the regulation is removed
+    // Removing a regulation can cause multiple static properties to be removed as well.
+    // Sometimes, only a subset of these events is correctly displayed on the UI side.
+    // A hacky way to avoid these inconsistency issues is to wait and refresh backend state atomically.
     setTimeout(() => {
       aeonState.sketch.properties.refreshStaticProps()
-    }, 50)
+    }, 75)
+  }
+
+  /** Process function removal coming from the backend. */
+  #onFunctionRemoved (data: UninterpretedFnData): void {
+    this.saveFunctions(
+      this.data.functions.filter((uninterpretedFn) => uninterpretedFn.id !== data.id)
+    )
+
+    // Removing a function can cause multiple static properties to be removed as well.
+    // Sometimes, only a subset of these events is correctly displayed on the UI side.
+    // A hacky way to avoid these inconsistency issues is to wait and refresh backend state atomically.
+    setTimeout(() => {
+      aeonState.sketch.properties.refreshStaticProps()
+    }, 75)
   }
 
   /** Process and save refreshed sketch data coming from the backend. */


### PR DESCRIPTION
This PR finally addresses many issues with the function editor that were neglected for some time:
- Editing monotonicity and essentiality of supplementary function arguments is now automatically propagated into static properties. Changes to supplementary functions are automatically reflected in corresponding properties as well. This addresses issue #64.
- Expressions of supplementary functions are now propagated into update functions before starting the inference. This addresses issue #70.
- The UI for manipulating the arity of supplementary functions changed. The weird way of arity decrement was changed to a simple button. This partially addresses issue #69, but there is still some room to improve this one.
- A new method to check the format of IDs of automatically generated static properties was added to all import events.
- Consistency check now looks for function symbols that are not used in any expression.
- If inference fails due to some internal error, the error message displayed in the UI now also points to the part of the algorithm where the issue occurred.

A few bugs were fixed, for instance:
- Some static property encoding methods were missing parentheses, causing parsing errors during inference. The formulas were fixed.
- Properties referencing pruned function symbols were causing errors. These properties of unused functions are now filtered during inference. 

There were also larger refactoring changes:
- So-called "placeholder" variables to track formal arguments of uninterpreted functions are no longer part of the model. This implementation redundancy is now gone, tracking the arguments without it.
- Many methods of structs `FnTree`, `UninterpretedFn`, and `UpdateFn` were updated and documented.
- Redundant events to increment/decrement function arity were replaced with a more general way.
- Some parts of the logic in the function editor frontend were redesigned.
- A struct for FOL parse tree was simplified to avoid redundant `Box`es.